### PR TITLE
Hotfix to make it to version 0.1.1

### DIFF
--- a/qasm_flex_bison/library/lex.l
+++ b/qasm_flex_bison/library/lex.l
@@ -21,7 +21,7 @@ singlenewline      (\n|\r\n)
 comment            \#(.*){singlenewline}*
 nonneginteger      [0-9]+
 integer            (\-)?{nonneginteger}
-float              (\-)?({nonneginteger}\.{nonneginteger})[eE]?((\-)?{nonneginteger})?
+float              (\-)?({nonneginteger}\.{nonneginteger}*)[eE]?((\-)?{nonneginteger})?
 axis               ([xX]|[yY]|[zZ])
 single_qubits      ((?i:i)|(?i:h)|(?i:x90)|(?i:y90)|(?i:mx90)|(?i:my90)|(?i:s)|(?i:sdag)|(?i:t)|(?i:tdag))
 two_qubit_gates    ((?i:cnot)|(?i:cz)|(?i:swap))


### PR DESCRIPTION
Fixes the issue (#60) where the string noninteger. is not being parsed as float by changing the lexer.