### PR TITLE
Fix for issue #70

### DIFF
--- a/qasm_flex_bison/library/grammar.y
+++ b/qasm_flex_bison/library/grammar.y
@@ -166,6 +166,11 @@ qubit-register : QUBITS WS INTEGER
 error-model : ERROR_MODEL_KEY WS ERROR_MODEL COMMA_SEPARATOR FLOAT
               {
                   qasm_representation.setErrorModel( std::string($3), $5 );
+              }
+              |
+              ERROR_MODEL_KEY WS ERROR_MODEL COMMA_SEPARATOR INTEGER
+              {
+                  qasm_representation.setErrorModel( std::string($3), $5 );
               }  
     ;
 //# We define the syntax for selecting the qubits/bits, either by a range or a list


### PR DESCRIPTION
Fixes the issue of syntax error when a user passes an integer as the error model parameter. See issue #70