### PR TITLE
Fixes issue #80

### DIFF
--- a/qasm_flex_bison/library/qasm_ast.hpp
+++ b/qasm_flex_bison/library/qasm_ast.hpp
@@ -594,7 +594,11 @@ namespace compiler
     // This class is supposed to provide an encapsulation of all the objects within the qasm file
     {
         public:
-            QasmRepresentation() = default;
+            QasmRepresentation()
+            {
+                std::vector<double> default_param(1, 0.);
+                setErrorModel("None", default_param);
+            }
 
             void qubitRegister(int participating_number)
             {
@@ -643,20 +647,20 @@ namespace compiler
                                                            name_key + ": Line " + std::to_string(linenumber));
             }
 
-            void setErrorModel(std::string error_model_type, double probability)
+            void setErrorModel(std::string error_model_type, std::vector<double> error_model_num_params)
             {
-                error_model_params_.first = error_model_type;
-                error_model_params_.second = probability;
+                error_model_.first = error_model_type;
+                error_model_.second = error_model_num_params;
             }
 
             const std::string getErrorModelType() const
             {
-                return error_model_params_.first;
+                return error_model_.first;
             }
 
-            double getErrorModelProbability() const
+            std::vector<double> getErrorModelParameters() const
             {
-                return error_model_params_.second;
+                return error_model_.second;
             }
 
             void printMappings() const
@@ -673,8 +677,11 @@ namespace compiler
             void printErrorModel() const
             // This is just for debugging purposes
             {
-                std::cout << "Current error model: " << error_model_params_.first
-                          << "\nError Probability = "  << error_model_params_.second << std::endl;
+                std::cout << "Current error model: " << error_model_.first
+                          << "\nError Probability = " ;
+                for (auto i : getErrorModelParameters()){
+                    std::cout << i << std::endl;
+                }
             }
 
         protected:
@@ -682,7 +689,7 @@ namespace compiler
             int qubit_register_;
             double version_number_;
             std::map< std::string , std::pair<NumericalIdentifiers,bool> > mappings_;
-            std::pair< std::string, double > error_model_params_ = std::make_pair("None",0.);
+            std::pair< std::string, std::vector<double> > error_model_;
     }; // class QasmRepresentation
 } //namespace compiler
 

--- a/qasm_flex_bison/test/testqc.cpp
+++ b/qasm_flex_bison/test/testqc.cpp
@@ -19,6 +19,17 @@ TEST_CASE("Test for the testqc.qasm file")
     compiler::QasmSemanticChecker sm(myfile);
 
     auto qasm_representation = sm.getQasmRepresentation();
+
+    auto error_model_params = qasm_representation.getErrorModelParameters();
+
+    std::vector<double> true_results_ = {0.001, 0.1, 3.4};
+
+    CHECK(true_results_.size() == error_model_params.size());
+
+    for (size_t i = 0; i < error_model_params.size(); ++i)
+    {
+        CHECK(error_model_params.at(i) == true_results_.at(i));
+    }
     
     int result = sm.parseResult();
 

--- a/qasm_flex_bison/test/testqc.qasm
+++ b/qasm_flex_bison/test/testqc.qasm
@@ -56,6 +56,7 @@ map q[7] , q7
    crk q1, q6, 4
    crk q2, q3, -10
    cr q2, q5, 3.1416
+   U q1, [1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0]
 
 .result
 # measurement
@@ -72,4 +73,4 @@ load_state "test.qc"
 
 
 display bleh
-error_model depolarizing_channel ,0.001
+error_model depolarizing_channel ,0.001, 0.1, 3.4


### PR DESCRIPTION
* Adds multiple numerical parameters support to the error model syntax.
* Modifies the function call to getErrorModelParameters() which will now return a vector of the error model parameters.
* Matrix arguments to the custom gate U are now in the syntax: U qubit , [mat00_real, ...mat11_imag]