### PR TITLE
Fix CXX requirements to require C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,9 @@ endif()
 
 project(cqasm CXX)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 # Library type option. Default is a static library.
 option(
     BUILD_SHARED_LIBS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ project(cqasm CXX)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 # Library type option. Default is a static library.
 option(

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -198,3 +198,13 @@ install(
     DESTINATION "${LIBQASM_CQASM_PYTHON_DIR}/v1"
     RENAME "values.py"
 )
+
+# add tests that can be run by pytest to cmake
+find_package(Python3 COMPONENTS Interpreter)
+if(Python3_Interpreter_FOUND)
+    add_test(
+        NAME pytest
+        COMMAND Python3::Interpreter -m pytest
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+endif()

--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,7 @@ setup(
     ],
     install_requires = [
         'msvc-runtime; platform_system == "Windows"',
+        'numpy'
     ],
     tests_require = [
         'pytest'


### PR DESCRIPTION
Before this change I got errors like:

```
/code/qutech/libqasm/src/cqasm/tree-gen/include/tree-base.hpp.inc:1198:48: error: expected ';' at end of declaration
    Many<typename std::remove_const<T>::type> c{};
                                               ^
                                               ;
/code/qutech/libqasm/src/cqasm/tree-gen/include/tree-base.hpp.inc:1199:10: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
    for (auto &sptr : this->vec) {
         ^

```
When building on my machine. It appears that this library was written against the C++11 version of the C++ standard.

This can be fixed by defining the required C++ version in the CMAKE file.

It might have build fine on other machines that already use C++11 by default.

