### PR TITLE
fix CXX version requirement

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
 /.git
 /Dockerfile
 /build
+/cbuild
+/pybuild
+/.eggs
+/.pytest_cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,10 @@ endif()
 
 project(cqasm CXX)
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 # Library type option. Default is a static library.
 option(
     BUILD_SHARED_LIBS

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM python:${PYTHON_VERSION}-buster
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update &&\
-    apt install -y bison build-essential cmake git swig
+    apt install -y bison build-essential cmake git swig &&\
+    python -m pip install pytest
 
 ADD . /src
 
@@ -13,4 +14,8 @@ RUN cmake /src -DLIBQASM_BUILD_TESTS=ON -DLIBQASM_COMPAT=ON -DTREE_GEN_BUILD_TES
 RUN make -j 1
 RUN make test CTEST_OUTPUT_ON_FAILURE=TRUE
 RUN make install
+
+WORKDIR /src
+RUN python -m pip install .
+RUN python -m pytest
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+testpaths = [
+    "src/tests/python"
+]

--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,7 @@ setup(
     ],
     install_requires = [
         'msvc-runtime; platform_system == "Windows"',
+        'numpy'
     ],
     tests_require = [
         'pytest'


### PR DESCRIPTION
This adresses the reviewer remarks in #139

Before this change I got errors like:

```
/code/qutech/libqasm/src/cqasm/tree-gen/include/tree-base.hpp.inc:1198:48: error: expected ';' at end of declaration
    Many<typename std::remove_const<T>::type> c{};
                                               ^
                                               ;
/code/qutech/libqasm/src/cqasm/tree-gen/include/tree-base.hpp.inc:1199:10: warning: 'auto' type specifier is a C++11 extension [-Wc++11-extensions]
    for (auto &sptr : this->vec) {
         ^

```
When building on my machine. It appears that this library was written against the C++11 version of the C++ standard.

This can be fixed by defining the required C++ version in the CMAKE file.

It might have build fine on other machines that already use C++11 by default.

