### PR TITLE
Fix Bison building old 3.0 version

### DIFF
--- a/src/cqasm/CMakeLists.txt
+++ b/src/cqasm/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 # Require flex/bison; if not installed, this will try to build from source.
 set(FLEX_VERSION_REQUIRED 2.6.1)
 set(BISON_VERSION_REQUIRED 3.0)
+set(BISON_VERSION_TO_BUILD 3.8)
 include(cmake/flex-bison.cmake)
 if(WIN32)
     set(flex_win_compat --wincompat)

--- a/src/cqasm/cmake/bison-download.cmake
+++ b/src/cqasm/cmake/bison-download.cmake
@@ -2,10 +2,14 @@ cmake_minimum_required(VERSION 2.8.2)
 
 project(bison-download NONE)
 
+if("${BISON_VERSION_TO_BUILD}" VERSION_LESS "${BISON_VERSION_REQUIRED}")
+    message(FATAL_ERROR "Bison version to build should be greater or equal to the minimum required Bison version.")
+endif()
+
 include(ExternalProject)
 ExternalProject_Add(
     bison
-    URL "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION_REQUIRED}.tar.gz"
+    URL "https://ftp.gnu.org/gnu/bison/bison-${BISON_VERSION_TO_BUILD}.tar.gz"
     SOURCE_DIR "${CMAKE_CURRENT_BINARY_DIR}/bison-build"
     INSTALL_DIR "${CMAKE_CURRENT_BINARY_DIR}/bison-install"
     CONFIGURE_COMMAND ""

--- a/src/cqasm/cmake/flex-bison.cmake
+++ b/src/cqasm/cmake/flex-bison.cmake
@@ -67,7 +67,7 @@ endif()
 
 if(NOT BISON_FOUND)
 
-    message(WARNING "bison ${BISON_VERSION_REQUIRED} not found on your system. trying to build from source...")
+    message(WARNING "bison ${BISON_VERSION_REQUIRED} not found on your system. trying to build Bison ${BISON_VERSION_TO_BUILD} from source...")
 
     configure_file(
         "${CMAKE_CURRENT_SOURCE_DIR}/cmake/bison-download.cmake"
@@ -80,7 +80,7 @@ if(NOT BISON_FOUND)
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bison-download"
     )
     if(result)
-        message(FATAL_ERROR "download step for bison ${BISON_VERSION_REQUIRED} failed: ${result}")
+        message(FATAL_ERROR "download step for bison ${BISON_VERSION_TO_BUILD} failed: ${result}")
     endif()
 
     execute_process(
@@ -89,7 +89,7 @@ if(NOT BISON_FOUND)
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bison-download"
     )
     if(result)
-        message(FATAL_ERROR "download step for bison ${BISON_VERSION_REQUIRED} failed: ${result}")
+        message(FATAL_ERROR "download step for bison ${BISON_VERSION_TO_BUILD} failed: ${result}")
     endif()
 
     execute_process(
@@ -98,7 +98,7 @@ if(NOT BISON_FOUND)
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bison-build"
     )
     if(result)
-        message(FATAL_ERROR "configure step for bison ${BISON_VERSION_REQUIRED} failed: ${result}")
+        message(FATAL_ERROR "configure step for bison ${BISON_VERSION_TO_BUILD} failed: ${result}")
     endif()
 
     execute_process(
@@ -107,7 +107,7 @@ if(NOT BISON_FOUND)
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bison-build"
     )
     if(result)
-        message(FATAL_ERROR "build step for bison ${BISON_VERSION_REQUIRED} failed: ${result}")
+        message(FATAL_ERROR "build step for bison ${BISON_VERSION_TO_BUILD} failed: ${result}")
     endif()
 
     execute_process(
@@ -116,7 +116,7 @@ if(NOT BISON_FOUND)
         WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bison-build"
     )
     if(result)
-        message(FATAL_ERROR "install step for bison ${BISON_VERSION_REQUIRED} failed: ${result}")
+        message(FATAL_ERROR "install step for bison ${BISON_VERSION_TO_BUILD} failed: ${result}")
     endif()
 
     # Add the binary directory to the system environment path. Not sure if this
@@ -133,7 +133,7 @@ if(NOT BISON_FOUND)
 
     # Find again.
     find_package(
-        BISON ${BISON_VERSION_REQUIRED} EXACT
+        BISON ${BISON_VERSION_TO_BUILD} EXACT
         REQUIRED
     )
 


### PR DESCRIPTION
With this commit, if Bison is not preinstalled on the system, version 3.8 will be built, instead of too old version 3.0, which doesn't build with newer glibc.