### PR TITLE
Removed compilation warnings.

### DIFF
--- a/src/cqasm/include/cqasm-v1-primitives.hpp
+++ b/src/cqasm/include/cqasm-v1-primitives.hpp
@@ -28,7 +28,7 @@ namespace primitives {
  * generated tree nodes to ensure that there's no garbage in the nodes.
  */
 template <class T>
-T initialize() { return T(); };
+T initialize() { return T(); }
 
 /**
  * Serializes the given primitive object to CBOR.
@@ -120,28 +120,28 @@ public:
      * Creates an empty matrix.
      */
     Matrix()
-        : data(ncols), nrows(1), ncols(0)
+        : data(0), nrows(1), ncols(0)
     {}
 
     /**
      * Creates a vector.
      */
-    Matrix(size_t ncols)
-        : data(ncols), nrows(1), ncols(ncols)
+    explicit Matrix(size_t cols)
+        : data(cols), nrows(1), ncols(cols)
     {}
 
     /**
      * Creates a zero-initialized matrix of the given size.
      */
-    Matrix(size_t nrows, size_t ncols)
-        : data(nrows*ncols), nrows(nrows), ncols(ncols)
+    Matrix(size_t rows, size_t cols)
+        : data(rows*cols), nrows(rows), ncols(cols)
     {}
 
     /**
      * Creates a column vector with the given data.
      */
-    Matrix(const std::vector<T> &data)
-        : data(data), nrows(data.size()), ncols(1)
+    explicit Matrix(const std::vector<T> &vec)
+        : data(vec), nrows(vec.size()), ncols(1)
     {}
 
     /**
@@ -149,12 +149,14 @@ public:
      * the number of data elements is not divisible by the number of columns, a
      * range error is thrown.
      */
-    Matrix(const std::vector<T> &data, size_t ncols)
-        : data(data), nrows(data.size() / ncols), ncols(ncols)
+    Matrix(const std::vector<T> &vec, size_t cols)
     {
-        if (data.size() % ncols != 0) {
+        if (vec.size() % cols != 0) {
             throw std::range_error("invalid matrix shape");
         }
+        data = vec;
+        nrows = vec.size() / cols;
+        ncols = cols;
     }
 
     /**

--- a/src/cqasm/src/cqasm-v1-error-model.cpp
+++ b/src/cqasm/src/cqasm-v1-error-model.cpp
@@ -77,7 +77,7 @@ error_model::ErrorModelRef deserialize(const ::tree::cbor::MapReader &map) {
     for (size_t i = 0; i < ar.size(); i++) {
         model->param_types.add(::tree::base::deserialize<types::Node>(ar.at(i).as_binary()));
     }
-    return std::move(model);
+    return model;
 }
 
 } // namespace primitives

--- a/src/cqasm/src/cqasm-v1-instruction.cpp
+++ b/src/cqasm/src/cqasm-v1-instruction.cpp
@@ -108,7 +108,7 @@ instruction::InstructionRef deserialize(const ::tree::cbor::MapReader &map) {
     for (size_t i = 0; i < ar.size(); i++) {
         insn->param_types.add(::tree::base::deserialize<types::Node>(ar.at(i).as_binary()));
     }
-    return std::move(insn);
+    return insn;
 }
 
 } // namespace primitives

--- a/src/cqasm/src/cqasm-v1-parser.y
+++ b/src/cqasm/src/cqasm-v1-parser.y
@@ -242,7 +242,7 @@ priority than '|' */
 %left '@'
 
 /* Misc. Yacc directives */
-%error-verbose
+%define parse.error verbose
 %start Root
 
 %%


### PR DESCRIPTION
- Warnings complained about data being initialized from an uninitialized ncols. This may be a false positive, due to the constructor parameter being called like the member variable. Anyway, it can be easily fixed by renaming the parameter (having parameter names equal to member names can be quite confusing).
- Made constructors receiving one single parameter explicit.
- Removed an extra semicolon at the end of the initialize function template.