### PR TITLE
DRAFT: Fix memory leak for QI

### DIFF
--- a/python/libQasm.i
+++ b/python/libQasm.i
@@ -46,7 +46,7 @@ namespace std {
 %include "cqasm-py.hpp"
 
 namespace std {
-    %template(subcircuit_vector) vector<compiler::SubCircuit>;
+    %template(subcircuit_vector) vector<compiler::SubCircuit*>;
     %template(operationscluster_vector) vector<compiler::OperationsCluster*>;
     %template(operation_vector) vector<compiler::Operation*>;
     %template(twoqubitgatequbits_pair) pair<compiler::Qubits, compiler::Qubits>;

--- a/src/library/libQasm.hpp
+++ b/src/library/libQasm.hpp
@@ -13,13 +13,18 @@ class libQasm
     public:
         libQasm()
         {
+            sm_ = nullptr;
+        }
+
+        ~libQasm()
+        {
+            delete sm_;
         }
 
         void parse_string(const char* qasm_str)
         {
+            delete sm_;
             sm_ = new compiler::QasmSemanticChecker(qasm_str);
-            qasm_rep_ = sm_->getQasmRepresentation();
-            parse_result_ = sm_->parseResult();
         }
 
         void parse_file(const char* qasm_file_path)
@@ -31,25 +36,22 @@ class libQasm
                     + std::string(" not found!\n");
                 throw std::runtime_error(file_not_found);
             }
+            delete sm_;
             sm_ = new compiler::QasmSemanticChecker(qasm_file);
-            qasm_rep_ = sm_->getQasmRepresentation();
-            parse_result_ = sm_->parseResult();
         }
 
         int getParseResult() const
         {
-            return parse_result_;
+            return sm_->parseResult();
         }
 
         const compiler::QasmRepresentation& getQasmRepresentation() const
         {
-            return qasm_rep_;
+            return sm_->getQasmRepresentation();
         }
 
     private:
         compiler::QasmSemanticChecker* sm_;
-        compiler::QasmRepresentation qasm_rep_;
-        int parse_result_;
 };
 
 #endif  // LIBQASM_HPP

--- a/src/library/qasm_ast.hpp
+++ b/src/library/qasm_ast.hpp
@@ -445,6 +445,15 @@ namespace compiler
                 linenumber_ = linenumber;
             }
 
+            ~OperationsCluster()
+            {
+                for (Operation* op : operations_)
+                {
+                    delete op;
+                }
+                operations_.clear();
+            }
+
             Operation* lastOperation()
             {
                 return operations_.back();
@@ -522,6 +531,15 @@ namespace compiler
             {
             }
 
+            ~SubCircuit()
+            {
+                for (OperationsCluster* opclus : operations_cluster_)
+                {
+                    delete opclus;
+                }
+                operations_cluster_.clear();
+            }
+
             int numberIterations() const
             {
                 return number_iterations_;
@@ -586,11 +604,20 @@ namespace compiler
         public:
             SubCircuits()
             {
-                SubCircuit default_circuit("default", 0, 1);
+                SubCircuit *default_circuit = new SubCircuit("default", 0, 1);
                 subcircuits_.push_back ( default_circuit );
             }
 
-            void addSubCircuit(SubCircuit subcircuit)
+            ~SubCircuits()
+            {
+                for (SubCircuit* sc : subcircuits_)
+                {
+                    delete sc;
+                }
+                subcircuits_.clear();
+            }
+
+            void addSubCircuit(SubCircuit *subcircuit)
             {
                 subcircuits_.push_back(subcircuit);
             }
@@ -600,20 +627,28 @@ namespace compiler
                 return subcircuits_.size();
             }
 
-            SubCircuit& lastSubCircuit()
+            SubCircuit* lastSubCircuit()
             {
                 return subcircuits_.back();
             }
 
-            const std::vector<SubCircuit>& getAllSubCircuits() const
+            const std::vector<SubCircuit*>& getAllSubCircuits() const
             {
                 return subcircuits_;
             }
 
-            void clearSubCircuits() { subcircuits_.clear(); }
+            void clearSubCircuits()
+            {
+                for (SubCircuit* sc : subcircuits_)
+                {
+                    delete sc;
+                }
+
+                subcircuits_.clear();
+            }
 
         protected:
-            std::vector<SubCircuit> subcircuits_;
+            std::vector<SubCircuit*> subcircuits_;
     }; //class SubCircuits
 
     class QasmRepresentation

--- a/src/library/qasm_new_to_old.hpp
+++ b/src/library/qasm_new_to_old.hpp
@@ -341,12 +341,12 @@ static void handle_parse_result(QasmRepresentation &qasm, cqasm::parser::ParseRe
             if (auto loc = subcircuit->get_annotation_ptr<cqasm::parser::SourceLocation>()) {
                 line_number = loc->first_line;
             }
-            SubCircuit sc {
+            SubCircuit *sc = new SubCircuit(
                 subcircuit->name.c_str(),
                 (int)scs.numberOfSubCircuits(),
                 line_number
-            };
-            sc.numberIterations(subcircuit->iterations);
+            );
+            sc->numberIterations(subcircuit->iterations);
             scs.addSubCircuit(sc);
         }
 
@@ -383,7 +383,7 @@ static void handle_parse_result(QasmRepresentation &qasm, cqasm::parser::ParseRe
             // Add the cluster to the last subcircuit if the bundle
             // was nonempty.
             if (opclus) {
-                scs.lastSubCircuit().addOperationsCluster(opclus);
+                scs.lastSubCircuit()->addOperationsCluster(opclus);
             }
         }
     }

--- a/src/library/qasm_semantic.hpp
+++ b/src/library/qasm_semantic.hpp
@@ -58,16 +58,16 @@ namespace compiler
                 int checkResult = 0;
                 for (auto subcircuit : qasm_.getSubCircuits().getAllSubCircuits())
                 {
-                    if (subcircuit.numberIterations() < 1)
+                    if (subcircuit->numberIterations() < 1)
                     {
                         std::string base_error_message("Iteration count invalid for subcircuit");
                         std::string entire_error_message = base_error_message +
-                                                           " " + subcircuit.nameSubCircuit() +
+                                                           " " + subcircuit->nameSubCircuit() +
                                                            " on Line: " +
-                                                           std::to_string(subcircuit.getLineNumber());
+                                                           std::to_string(subcircuit->getLineNumber());
                         throw std::runtime_error(entire_error_message);
                     }
-                    for (auto ops_cluster : subcircuit.getOperationsCluster())
+                    for (auto ops_cluster : subcircuit->getOperationsCluster())
                     {
                         int linenumber = ops_cluster->getLineNumber();
                         for (auto ops : ops_cluster->getOperations())

--- a/src/tests/cpp/bare_minimum.cpp
+++ b/src/tests/cpp/bare_minimum.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test for the bare_minimum.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 

--- a/src/tests/cpp/barriers.cpp
+++ b/src/tests/cpp/barriers.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Test for the barriers.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 

--- a/src/tests/cpp/bell.cpp
+++ b/src/tests/cpp/bell.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test for the bell.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 

--- a/src/tests/cpp/example2.cpp
+++ b/src/tests/cpp/example2.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test for the example2.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 

--- a/src/tests/cpp/example3.cpp
+++ b/src/tests/cpp/example3.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test for the example3.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 

--- a/src/tests/cpp/example7.cpp
+++ b/src/tests/cpp/example7.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test for the example7.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 

--- a/src/tests/cpp/grover.cpp
+++ b/src/tests/cpp/grover.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test for the grover.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 

--- a/src/tests/cpp/qc.cpp
+++ b/src/tests/cpp/qc.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Test for the testqc.qasm file")
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     auto error_model_params = qasm_representation.getErrorModelParameters();
 

--- a/src/tests/cpp/wait.cpp
+++ b/src/tests/cpp/wait.cpp
@@ -21,13 +21,12 @@ TEST_CASE("Test for the wait.qasm file")
     extern int yydebug;
     yydebug = 1;
     #endif
-
     // open a file handle to a particular file:
-    FILE *myfile = fopen("wait.qasm", "r");
+    FILE* myfile = fopen("wait.qasm", "r");
 
     compiler::QasmSemanticChecker sm(myfile);
 
-    auto qasm_representation = sm.getQasmRepresentation();
+    auto &qasm_representation = sm.getQasmRepresentation();
 
     int result = sm.parseResult();
 


### PR DESCRIPTION
* Solved memory leaks for huge cqasm files as encountered in QI (issue #151)
* changed code where objects were copied (without copy constructors) invalidating the pointers
* Added destructors to delete memory for vectors with pointer types
* Changed vector of <SubCircuit> to <SubCircuit *>
* Free memory when calling parse_file twice
* Changed some test code to correctly use the objects from the library