### PR TITLE
Changed 'v3' to 'develop' for 'on-push-branches'. [skip ci]

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-    - v3
+    - develop
   pull_request:
 
 jobs:


### PR DESCRIPTION
I'm sorry, I don't know why this last change didn't go into the 'v3' PR.