### PR TITLE
Toy v1 infrastructure amend.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -123,7 +123,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         shell: powershell
         run: |
-          echo "LIBQASM_BUILD_TYPE=Release" >> $GITHUB_ENV
+          echo "LIBQASM_BUILD_TYPE=Release" >> $env:GITHUB_ENV
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build

--- a/conanfile.py
+++ b/conanfile.py
@@ -47,7 +47,7 @@ class LibqasmConan(ConanFile):
         "tree_gen_build_tests": False
     }
 
-    exports_sources = "CMakeLists.txt", "3rd_party/*", "include/*", "python/*", "res/*", "scripts/*", "src/*", "test/*"
+    exports_sources = "CMakeLists.txt", "include/*", "python/*", "res/*", "scripts/*", "src/*", "test/*"
 
     def build_requirements(self):
         self.tool_requires("m4/1.4.19")

--- a/include/cqasm.hpp
+++ b/include/cqasm.hpp
@@ -9,3 +9,4 @@
 #pragma once
 
 #include "v1x/cqasm.hpp"
+#include "v3x/cqasm.hpp"

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ class build_ext(_build_ext):
 
         # If we were previously built in a different directory,
         # nuke the cbuild dir to prevent inane CMake errors.
-        # This happens when the user does 'pip install .' after building locally.
+        # This happens when the user does 'pip install .' after building locally
         if os.path.exists(cbuild_dir + os.sep + 'CMakeCache.txt'):
             with open(cbuild_dir + os.sep + 'CMakeCache.txt', 'r') as f:
                 for line in f.read().split('\n'):
@@ -72,19 +72,19 @@ class build_ext(_build_ext):
                             shutil.rmtree(cbuild_dir)
                         break
 
-        # Figure out how setuptools wants to name the extension file and where it wants to place it.
+        # Figure out how setuptools wants to name the extension file and where it wants to place it
         cqasm_target = os.path.abspath(self.get_ext_fullpath('cqasm._cqasm'))
         target = os.path.abspath(self.get_ext_fullpath('libQasm._libQasm'))
 
-        # Build the Python module and install it into module_dir.
+        # Build the Python extension and install it where setuptools expects it
         if not os.path.exists(cbuild_dir):
             os.makedirs(cbuild_dir)
 
-        # Build type can be set using an environment variable.
-        build_type = os.environ.get('LIBQASM_BUILD_TYPE', 'Release')
-
         # Configure and build using Conan
         with local.cwd(root_dir):
+            # Build type can be set using an environment variable
+            build_type = os.environ.get('LIBQASM_BUILD_TYPE', 'Release')
+
             cmd = local['conan']['profile']['detect']['--force']
             cmd & FG
 
@@ -93,23 +93,23 @@ class build_ext(_build_ext):
                 ['-s:h']['compiler.cppstd=20']
                 ['-s:h']["libqasm/*:build_type=" + build_type]
 
-                # (Ab)use static libs for the intermediate libraries
-                # to avoid dealing with R(UN)PATH nonsense on Linux/OSX as much as possible.
-                ['-o']["libqasm/*:shared=False"]
-                # The Python library needs the compatibility headers.
-                ['-o']["libqasm/*:compat=True"]
-                ['-o']['libqasm/*:build_tests=True']
                 ['-o']['libqasm/*:build_python=True']
+                ['-o']['libqasm/*:build_tests=True']
+                # The Python library needs the compatibility headers
+                ['-o']["libqasm/*:compat=True"]
                 ['-o']['libqasm/*:cqasm_python_dir=' + re.escape(os.path.dirname(cqasm_target))]
                 ['-o']['libqasm/*:python_dir=' + re.escape(os.path.dirname(target))]
                 ['-o']['libqasm/*:python_ext=' + re.escape(os.path.basename(target))]
+                # (Ab)use static libs for the intermediate libraries
+                # to avoid dealing with R(UN)PATH nonsense on Linux/OSX as much as possible
+                ['-o']["libqasm/*:shared=False"]
 
                 ['-b']['missing']
                 ['-tf']['']
             )
-        if platform.system() == "Darwin":
-            cmd = cmd['-c']['tools.build:defines=["_LIBCPP_DISABLE_AVAILABILITY"]']
-        cmd & FG
+            if platform.system() == "Darwin":
+                cmd = cmd['-c']['tools.build:defines=["_LIBCPP_DISABLE_AVAILABILITY"]']
+            cmd & FG
 
 
 class build(_build):
@@ -191,8 +191,8 @@ setup(
     packages=['libQasm', 'cqasm', 'cqasm.v1x'],
     package_dir={'': 'pybuild/module'},
 
-    # NOTE: the library build process is completely overridden to let CMake handle it;
-    # setuptools' implementation is horribly broken.
+    # NOTE: the library build process is completely overridden to let CMake handle it.
+    # setuptools implementation is horribly broken.
     # This is here just to have the rest of setuptools understand that this is a Python module with an extension in it.
     ext_modules=[
         Extension('libQasm._libQasm', [])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,7 +202,6 @@ add_library(cqasm-lib-obj OBJECT
     ${CQASM_V1X_SOURCES}
     ${CQASM_V3X_SOURCES}
 )
-add_dependencies(cqasm-lib-obj antlr_target)
 
 target_compile_definitions(cqasm-lib-obj
     PRIVATE ${TREE_LIB_PRIVATE_DEFS}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -183,7 +183,7 @@ add_custom_command(
     OUTPUT ${ANTLR_OUTPUTS}
     COMMAND
         "${PYTHON_EXECUTABLE}"
-        "${CMAKE_SOURCE_DIR}/scripts/generate_antlr_parser.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_antlr_parser.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/v3x"  # Input dir (grammar files)
         "${CMAKE_CURRENT_BINARY_DIR}/v3x"  # Output dir (lexer and parser cpp files)
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,22 +173,24 @@ list(APPEND CQASM_V1X_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/v1x/cqasm-functions-g
 add_subdirectory(v3x)
 
 # Generate the lexer and the parser.
+function(antlr_target SCRIPT INPUT_DIR OUTPUT_DIR ANTLR_OUTPUTS)
+    add_custom_command(
+        OUTPUT ${ANTLR_OUTPUTS}
+        COMMAND ${PYTHON_EXECUTABLE} ${SCRIPT} ${INPUT_DIR} ${OUTPUT_DIR}
+    )
+endfunction()
+
 set(ANTLR_OUTPUTS
     "${CMAKE_CURRENT_BINARY_DIR}/v3x/cqasm_lexer.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/v3x/cqasm_parser.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/v3x/cqasm_parserBaseListener.cpp"
     "${CMAKE_CURRENT_BINARY_DIR}/v3x/cqasm_parserListener.cpp"
 )
-add_custom_command(
-    OUTPUT ${ANTLR_OUTPUTS}
-    COMMAND
-        "${PYTHON_EXECUTABLE}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_antlr_parser.py"
-        "${CMAKE_CURRENT_SOURCE_DIR}/v3x"  # Input dir (grammar files)
-        "${CMAKE_CURRENT_BINARY_DIR}/v3x"  # Output dir (lexer and parser cpp files)
-)
-add_custom_target(antlr_target ALL
-    DEPENDS ${ANTLR_OUTPUTS}
+antlr_target(
+    "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_antlr_parser.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/v3x"  # Input dir (grammar files)
+    "${CMAKE_CURRENT_BINARY_DIR}/v3x"  # Output dir (lexer and parser cpp files)
+    "${ANTLR_OUTPUTS}"  # List of generated files
 )
 list(APPEND CQASM_V3X_SOURCES ${ANTLR_OUTPUTS})
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -53,6 +53,7 @@ else()
 endif()
 
 find_package(antlr4-runtime REQUIRED)
+find_package(Python3 REQUIRED)
 
 #-------------------------------------------------------------------------------
 # cQASM common code generation and inclusion
@@ -176,7 +177,7 @@ add_subdirectory(v3x)
 function(antlr_target SCRIPT INPUT_DIR OUTPUT_DIR ANTLR_OUTPUTS)
     add_custom_command(
         OUTPUT ${ANTLR_OUTPUTS}
-        COMMAND ${PYTHON_EXECUTABLE} ${SCRIPT} ${INPUT_DIR} ${OUTPUT_DIR}
+        COMMAND ${Python3_EXECUTABLE} ${SCRIPT} ${INPUT_DIR} ${OUTPUT_DIR}
     )
 endfunction()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -202,6 +202,7 @@ add_library(cqasm-lib-obj OBJECT
     ${CQASM_V1X_SOURCES}
     ${CQASM_V3X_SOURCES}
 )
+add_dependencies(cqasm-lib-obj antlr_target)
 
 target_compile_definitions(cqasm-lib-obj
     PRIVATE ${TREE_LIB_PRIVATE_DEFS}

--- a/src/v3x/cqasm-parse-helper.cpp
+++ b/src/v3x/cqasm-parse-helper.cpp
@@ -4,6 +4,8 @@
 
 #include "v3x/cqasm-parse-helper.hpp"
 
+#include <stdexcept>  // runtime_error
+
 
 namespace cqasm {
 namespace v3x {
@@ -12,23 +14,23 @@ namespace parser {
 /**
  * Parse the given file.
  */
-ParseResult parse_file(const std::string &filename) {
-    return ParseHelper(filename, "", true).result;
+ParseResult parse_file(const std::string & /* filename */) {
+    throw std::runtime_error("Unimplemented");
 }
 
 /**
  * Parse using the given file pointer.
  */
-ParseResult parse_file(FILE *, const std::string &) {
-    return {};
+ParseResult parse_file(FILE * /* file */, const std::string & /* filename */) {
+    throw std::runtime_error("Unimplemented");
 }
 
 /**
  * Parse the given string. A filename may be given in addition for use within
  * error messages.
  */
-ParseResult parse_string(const std::string &, const std::string &) {
-    return {};
+ParseResult parse_string(const std::string & /* data */, const std::string & /* filename */) {
+    throw std::runtime_error("Unimplemented");
 }
 
 /**


### PR DESCRIPTION
When working on QI2_plan_2023's "OpenQL: v1, v3 reader" task, I noticed a few things to be fixed yet from my last PR.

- `CMakeLists.txt`:
  - fixed path to `generate_antlr_parser.py` when libqasm is used as a dependency.
  - fixed `add_custom_command`'s `COMMAND` so that it now works when adding `libqasm` as a dependency to `OpenQL`.
  - rewritten the ANTLR section to resemble the generation of Flex/Bison files, i.e., having an `antlr_target` that is actually a call to a function doing the `add_custom_command`.
- `conanfile.py`: removed `3rd_party` folder from `exports_sources`.
- `cqasm.hpp`: included `"v3x/cqasm.hpp"`.
- `setup.py`: minor changes, mostly aesthetic, apart from moving `build_type` definition and execution of `cmd` within the `with` block.
- `test.yml`: used `$env:GITHUB_ENV` instead of `GITHUB_ENV` for the Python/Windows job.