### PR TITLE
Toy v1 infrastructure amend 2.

### DIFF
--- a/doc/src/python-api.rst
+++ b/doc/src/python-api.rst
@@ -5,7 +5,7 @@ Besides the intended usage from C++, libqasm also has a (comparatively
 simplistic) Python interface, installable via the
 `libqasm <https://pypi.org/project/libqasm/>`_ PyPI package or using
 ``pip3 install -v -e .`` (or equivalent) from the root directory of the
-repository. This exposes two modules, ``libQasm`` and ``cqasm.v1``. The
+repository. This exposes two modules, ``libQasm`` and ``cqasm.v1x``. The
 former exists for backward compatibility with the original Python API,
 and supports only cQASM 1.0 and the default instruction set. The latter
 supports up to cQASM 1.2, mirroring the C++ API.
@@ -16,8 +16,8 @@ however. This should hopefully get you started:
 
 .. code-block:: python
 
-    import cqasm.v1
-    analyzer = cqasm.v1.Analyzer('1.2')
+    import cqasm.v1x
+    analyzer = cqasm.v1x.Analyzer('1.2')
     result = a.analyze_string('version 1.2; qubits 3; x q[0]')
 
 The argument passed to the ``Analyzer()`` constructor specifies the API version

--- a/include/v1x/README.md
+++ b/include/v1x/README.md
@@ -42,8 +42,9 @@ There are several ways in which you can link against the new API of libqasm:
 
    You can then link your targets against libqasm using `target_link_libraries(<your-target> <PRIVATE|PUBLIC> cqasm`.
    Again, depending on CMake's `BUILD_SHARED_LIBS` variable, shared or static linking will be used.
-   You can also link the objects directly into your target;
-   in this case `$<TARGET_OBJECTS:cqasm-lib-obj>` expands to the objects (add it to your target as if it's a source file).
+ 
+   You can also link the objects directly into your target.
+   In this case `$<TARGET_OBJECTS:cqasm-lib-obj>` expands to the objects (add it to your target as if it's a source file).
    You will need the following two lines in addition to copy over the public include directories and
    any dependencies of libqasm (currently there are none, this is for the sake of future-proofing) into your target:
    
@@ -63,50 +64,31 @@ There are several ways in which you can link against the new API of libqasm:
    1. Adding a `self.requires("libqasm/<version>")` to the `build_requirements` function of the conanfile.py, and
    2. Adding a `target_link_libraries(<your-target>  <PRIVATE|PUBLIC> ${CONAN_LIBS})` to the CMakeLists.txt file.
 
-### System installation via CMake
+### System installation
 
-When configuring the project using the `cmake` command,
-you may want to add one or more of the following command line arguments:
+This version of libqasm can only be compiled via `conan`.
+You may want to add one or more of the following command line arguments:
 
- - `-DBUILD_SHARED_LIBS=yes`: builds a shared object library instead of a static library, if applicable.
- - `-DLIBQASM_BUILD_TESTS=yes`: builds the tests in addition to the library itself.
-   Use `cmake --build . --target RUN_TESTS` to run the tests (in a cross-platform way) after building.
- - `-DCMAKE_INSTALL_PREFIX=<directory>`: specifies the directory that the library will be installed into when you run
-   `cmake --build . --target install`, in case you want to override whatever the default is for your OS.
-
-To be complete, here's an example for how to build a shared library, test it, and install it on Linux.
+- `-o libqasm/*:shared=True`: builds a shared object library instead of a static library, if applicable.
+- `-o libqasm/*:build_tests=True`: builds the tests in addition to the library itself.
+ 
+To be complete, here's an example for how to download, build as a shared library, install, and test libqasm on Linux.
 
 ```
-mkdir cbuild
-cd cbuild
-cmake .. -DBUILD_SHARED_LIBS=yes -DLIBQASM_BUILD_TESTS=yes
-cmake --build .
-make -j
-make test
-sudo make install
+git clone https://github.com/QuTech-Delft/libqasm.git
+cd libqasm
+conan profile detect
+conan create --version 0.4.1 . -s:h compiler.cppstd=20 -o libqasm/*:shared=True -o libqasm/*:build_tests=True -b missing
+cd build/Release
+ctest -c Release --output-on-failure
 ```
-
-### Conan build
-
-You can also use Conan for the build process. The command line arguments, in this case, would be:
-
-- `-o libqasm/*:shared=True`.
-- `-o libqasm/*:build_tests=True`.
-
-For example:
-
-```
-conan build . -s:h compiler.cppstd=20 -o libqasm/*:shared=True -o libqasm/*:build_tests=True -b missing
-```
-
-Then, you would still need the `sudo make install` to do the system installation. 
 
 ## File list
 
- - `src/v1`: contains the C++ source files for the library.
+ - `src/v1x`: contains the C++ source files for the library.
    May also contain private header files, but doesn't at the time of writing.
- - `include/v1`: contains the public header files for the library.
- - `test/v1`: contains the test suite for the library.
+ - `include/v1x`: contains the public header files for the library.
+ - `test/v1x`: contains the test suite for the library.
  - `src/func-gen`: contains a simple code generator for the repetitive logic of
    generating the operators and constant propagation functions exposed to
    cQASM.


### PR DESCRIPTION
Updated docs.
- Changed references from `v1` to `v1x`.
- Changed build instructions from `CMake` to `conan`.