### PR TITLE
Add conan profiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           conan profile detect
           build_type=${{ matrix.build_type }}
-          lowercase_build_type=${build_type,,}
+          lowercase_build_type=$(echo ${build_type} | tr '[:upper:]' '[:lower:]')
           conan build . -pr=conan/profiles/tests-${lowercase_build_type}-compat -b missing
         shell: bash
       - name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-    - add_conan_profiles
+    - develop
   pull_request:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches:
-    - develop
+    - add_conan_profiles
   pull_request:
 
 jobs:
@@ -43,7 +43,9 @@ jobs:
       - name: Configure and build
         run: |
           conan profile detect
-          conan build . -s:h compiler.cppstd=20 -s:h libqasm/*:build_type=${{ matrix.build_type }} -o libqasm/*:build_tests=True -o libqasm/*:compat=True -o libqasm/*:asan_enabled=True -b missing
+          build_type=${{ matrix.build_type }}
+          build_type=${build_type@L}
+          conan build . -pr=conan/profiles/tests-${build_type}-compat -b missing
       - name: Test
         working-directory: build/${{ matrix.build_type }}
         run: ctest -C ${{ matrix.build_type }} --output-on-failure
@@ -87,7 +89,7 @@ jobs:
           python3 -m venv venv
           source venv/bin/activate
           python3 -m pip install --upgrade pip conan
-          conan build . -s:h compiler.cppstd=20 -s:h libqasm/*:build_type=Release -o libqasm/*:build_tests=True -o libqasm/*:compat=True -o libqasm/*:asan_enabled=True -b missing
+          conan build . -pr=conan/profiles/tests-release-compat -b missing
       - name: Test
         working-directory: build/Release
         run: ctest -C Release --output-on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,8 +44,8 @@ jobs:
         run: |
           conan profile detect
           build_type=${{ matrix.build_type }}
-          build_type=${build_type@L}
-          conan build . -pr=conan/profiles/tests-${build_type}-compat -b missing
+          lowercase_build_type=${build_type,,}
+          conan build . -pr=conan/profiles/tests-${lowercase_build_type}-compat -b missing
         shell: bash
       - name: Test
         working-directory: build/${{ matrix.build_type }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,7 @@ jobs:
           build_type=${{ matrix.build_type }}
           build_type=${build_type@L}
           conan build . -pr=conan/profiles/tests-${build_type}-compat -b missing
+        shell: bash
       - name: Test
         working-directory: build/${{ matrix.build_type }}
         run: ctest -C ${{ matrix.build_type }} --output-on-failure

--- a/README.md
+++ b/README.md
@@ -64,9 +64,14 @@ cd libqasm
 conan build . -pr=conan/profiles/tests-debug -b missing
 ```
 
+The command above is building `libqasm` in Debug mode with tests using the `tests-debug` profile.
+
+The `-b missing` parameter asks `conan` to build packages from sources
+in case it cannot find the binary packages for the current configuration (platform, OS, compiler, build type...). 
+
 ### Build profiles
 
-The command above is building `libqasm` in Debug mode with tests using the `tests-debug` profile.
+
 A group of predefined profiles is provided under the `conan/profiles` folder.
 They follow the `[tests-](debug|release)[-compat]` naming convention. For example:
   - `release` is a Release build without tests and compatibility with the original API.

--- a/README.md
+++ b/README.md
@@ -66,17 +66,13 @@ conan build . -pr=conan/profiles/tests-debug -b missing
 
 ### Build profiles
 
-The command above is building `libqasm` in debug mode with tests using the `debug-tests` profile.
+The command above is building `libqasm` in Debug mode with tests using the `tests-debug` profile.
+A group of predefined profiles is provided under the `conan/profiles` folder.
+They follow the `[tests-](debug|release)[-compat]` naming convention. For example:
+  - `release` is a Release build without tests and compatibility with the original API.
+  - `tests-debug-compat` is a Debug build with tests and compatibility enabled.
 
-libqasm provides a set of predefined profiles under the `conan/profiles` folder.
-
-All these files follow the `{tests,}-{debug,release}-{compat,}` naming convention. For example:
-  - `release` sets  `build_tests=False`, `build_type=Release` and `libqasm_compat=False`, and
-  - `test-debug-compat` sets `build_tests=True`, `build_type=Debug` and `libqasm_compat=True`.
-
-All the profiles set `compiler.cppstd=20`.
-
-All the `tests` profiles set `asan_enabled=True`.
+All the profiles set the C++ standard to 20. All the `tests` profiles enable Address Sanitizer.
 
 ### Build options
 
@@ -88,11 +84,12 @@ conan build . -s:h compiler.cppstd=20 -s:h libqasm/*:build_type=Debug -o libqasm
 
 These are the list of options that could be specified whether in a profile or in the command line:
 
-- `libqasm/*:build_tests={True,False}`: build tests or not.
+- `libqasm/*:build_tests={True,False}`: builds tests or not.
 - `libqasm/*:build_type={Debug,Release}`: builds in debug or release mode.
 - `libqasm/*:asan_enabled={True,False}`: enables Address Sanitizer.
-- `libqasm/*:compat={True,False}`: enables the compatibility layer.
-- `libqasm/*:shared={True,False}`: builds libqasm as a shared library.
+- `libqasm/*:compat={True,False}`: enables installation of the headers for the original API,
+on top of the ones for the new API.
+- `libqasm/*:shared={True,False}`: builds a shared object library instead of a static library, if applicable.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,42 @@ conan profile detect
 ```
 
 The installation of `libqasm` dependencies, as well as the compilation, can be done in one go.<br/>
-Notice the command below is building `libqasm` in Debug mode with tests.
 
 ```
 git clone https://github.com/QuTech-Delft/libqasm.git
 cd libqasm
-conan build . -s:h compiler.cppstd=20 -s:h libqasm/*:build_type=Debug -o libqasm/*:build_tests=True -b missing
+conan build . -pr=conan/profiles/tests-debug -b missing
 ```
+
+### Build profiles
+
+The command above is building `libqasm` in debug mode with tests using the `debug-tests` profile.
+
+libqasm provides a set of predefined profiles under the `conan/profiles` folder.
+
+All these files follow the `{tests,}-{debug,release}-{compat,}` naming convention. For example:
+  - `release` sets  `build_tests=False`, `build_type=Release` and `libqasm_compat=False`, and
+  - `test-debug-compat` sets `build_tests=True`, `build_type=Debug` and `libqasm_compat=True`.
+
+All the profiles set `compiler.cppstd=20`.
+
+All the `tests` profiles set `asan_enabled=True`.
+
+### Build options
+
+Profiles are a shorthand for command line options. The command above could be written as well as: 
+
+```
+conan build . -s:h compiler.cppstd=20 -s:h libqasm/*:build_type=Debug -o libqasm/*:asan_enabled=True -o libqasm/*:build_tests=True -o libqasm/*:compat=False -b missing
+```
+
+These are the list of options that could be specified whether in a profile or in the command line:
+
+- `libqasm/*:build_tests={True,False}`: build tests or not.
+- `libqasm/*:build_type={Debug,Release}`: builds in debug or release mode.
+- `libqasm/*:asan_enabled={True,False}`: enables Address Sanitizer.
+- `libqasm/*:compat={True,False}`: enables the compatibility layer.
+- `libqasm/*:shared={True,False}`: builds libqasm as a shared library.
 
 ## Install
 
@@ -72,7 +101,7 @@ conan build . -s:h compiler.cppstd=20 -s:h libqasm/*:build_type=Debug -o libqasm
 Install from the project root directory as follows:
 
 ```
-python -m pip install --verbose .
+python3 -m pip install --verbose .
 ```
 
 or if you'd rather use conda:
@@ -85,7 +114,7 @@ conda install libqasm --use-local
 You can test if it works by running:
 
 ```
-python -m pytest
+python3 -m pytest
 ```
 
 ### From C++

--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Debug
+
+[options]
+libqasm/*:asan_enabled=False
+libqasm/*:build_tests=False
+libqasm/*:compat=False

--- a/conan/profiles/debug-compat
+++ b/conan/profiles/debug-compat
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Debug
+
+[options]
+libqasm/*:asan_enabled=False
+libqasm/*:build_tests=False
+libqasm/*:compat=True

--- a/conan/profiles/release
+++ b/conan/profiles/release
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Release
+
+[options]
+libqasm/*:asan_enabled=False
+libqasm/*:build_tests=False
+libqasm/*:compat=False

--- a/conan/profiles/release-compat
+++ b/conan/profiles/release-compat
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Release
+
+[options]
+libqasm/*:asan_enabled=False
+libqasm/*:build_tests=False
+libqasm/*:compat=True

--- a/conan/profiles/tests-debug
+++ b/conan/profiles/tests-debug
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Debug
+
+[options]
+libqasm/*:asan_enabled=True
+libqasm/*:build_tests=True
+libqasm/*:compat=False

--- a/conan/profiles/tests-debug-compat
+++ b/conan/profiles/tests-debug-compat
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Debug
+
+[options]
+libqasm/*:asan_enabled=True
+libqasm/*:build_tests=True
+libqasm/*:compat=True

--- a/conan/profiles/tests-release
+++ b/conan/profiles/tests-release
@@ -5,6 +5,6 @@ compiler.cppstd=20
 libqasm/*:build_type=Release
 
 [options]
-libqasm/*:asan_enabled=False
+libqasm/*:asan_enabled=True
 libqasm/*:build_tests=True
 libqasm/*:compat=False

--- a/conan/profiles/tests-release
+++ b/conan/profiles/tests-release
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Release
+
+[options]
+libqasm/*:asan_enabled=False
+libqasm/*:build_tests=True
+libqasm/*:compat=False

--- a/conan/profiles/tests-release-compat
+++ b/conan/profiles/tests-release-compat
@@ -5,6 +5,6 @@ compiler.cppstd=20
 libqasm/*:build_type=Release
 
 [options]
-libqasm/*:asan_enabled=False
+libqasm/*:asan_enabled=True
 libqasm/*:build_tests=True
 libqasm/*:compat=True

--- a/conan/profiles/tests-release-compat
+++ b/conan/profiles/tests-release-compat
@@ -1,0 +1,10 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+libqasm/*:build_type=Release
+
+[options]
+libqasm/*:asan_enabled=False
+libqasm/*:build_tests=True
+libqasm/*:compat=True


### PR DESCRIPTION
Welcome `conan build . -pr=<path/to/profile> -b missing`! 😊

This PR tries to address issue [163](https://github.com/QuTech-Delft/libqasm/issues/163).

- Added a group of predefined profiles to `conan/profiles`.
  These profiles cover the most common build scenarios: tests on/off * debug/release * compatibility with original API on/off.
- Updated README.md.
- Updated `test.yml` to use conan profiles.