### PR TITLE
Fix measure instruction

### DIFF
--- a/include/v3x/AnalyzeTreeGenAstVisitor.hpp
+++ b/include/v3x/AnalyzeTreeGenAstVisitor.hpp
@@ -16,6 +16,7 @@ public:
     void visitVersion(const ast::Version &version_ast);
     void visitStatements(const ast::StatementList &statement_list_ast);
     void visitVariables(const ast::Variables &variables_ast);
+    tree::Maybe<semantic::Instruction> visitMeasureInstruction(const ast::MeasureInstruction &ast);
     tree::Maybe<semantic::Instruction> visitInstruction(const ast::Instruction &ast);
     values::Value visitExpression(const ast::Expression &ast);
     values::Value visitIndex(const ast::Index &ast);

--- a/include/v3x/cqasm-analyzer.hpp
+++ b/include/v3x/cqasm-analyzer.hpp
@@ -137,8 +137,7 @@ public:
      * Convenience method for registering an instruction type.
      * The arguments are passed straight to instruction::Instruction's constructor.
      */
-    void register_instruction(const std::string &name, const std::string &param_types = "",
-        bool request_qubit_and_bit_indices_have_same_size = false);
+    void register_instruction(const std::string &name, const std::string &param_types = "");
 
     /**
      * Analyzes the given program AST node.

--- a/include/v3x/cqasm-instruction.hpp
+++ b/include/v3x/cqasm-instruction.hpp
@@ -44,19 +44,11 @@ public:
     types::Types param_types;
 
     /**
-     * Whether qubit and bit indices have the same size (e.g. for a measure instruction).
-     */
-    bool request_qubit_and_bit_indices_have_same_size;
-
-    /**
      * Creates a new instruction.
      * param_types is a shorthand type specification string as parsed by cqasm::types::from_spec().
      * If you need more control, you can also manipulate param_types directly.
      */
-    explicit Instruction(
-        const std::string &name,
-        const std::string &param_types = "",
-        bool request_qubit_and_bit_indices_have_same_size = false);
+    explicit Instruction(const std::string &name, const std::string &param_types = "");
 
     bool operator==(const Instruction& rhs) const;
     inline bool operator!=(const Instruction& rhs) const {

--- a/include/v3x/cqasm-py.hpp
+++ b/include/v3x/cqasm-py.hpp
@@ -45,11 +45,7 @@ public:
      * Registers an instruction type.
      * The arguments are passed straight to instruction::Instruction's constructor.
      */
-    void register_instruction(
-        const std::string &name,
-        const std::string &param_types = "",
-        bool request_qubit_and_bit_indices_have_same_size = false
-    );
+    void register_instruction(const std::string &name, const std::string &param_types = "");
 
     /**
      * Only parses the given file.

--- a/python/module/cqasm/v3x/instruction.py
+++ b/python/module/cqasm/v3x/instruction.py
@@ -2,12 +2,7 @@ import cqasm.v3x.types
 
 
 class Instruction(object):
-    def __init__(
-        self,
-        name,
-        types=None,
-        request_qubit_and_bit_indices_have_same_size=False
-    ):
+    def __init__(self, name, types=None):
         super().__init__()
         self._name = str(name)
         if types is None:
@@ -17,7 +12,6 @@ class Instruction(object):
                 if not isinstance(typ, cqasm.v3x.types.Node):
                     raise TypeError('types must be an iterable of cqasm.v3x.types.Node if specified')
             self._types = tuple(types)
-        self._request_qubit_and_bit_indices_have_same_size = bool(request_qubit_and_bit_indices_have_same_size)
 
     @property
     def name(self):
@@ -26,10 +20,6 @@ class Instruction(object):
     @property
     def types(self):
         return self._types
-
-    @property
-    def request_qubit_and_bit_indices_have_same_size(self):
-        return self._request_qubit_and_bit_indices_have_same_size
 
     def __str__(self):
         return '{}({})'.format(self._name, ', '.join(map(str, self._types)))

--- a/python/module/cqasm/v3x/primitives.py
+++ b/python/module/cqasm/v3x/primitives.py
@@ -38,7 +38,6 @@ def serialize(typ, val):
         else:
             return {
                 'n': val.data.name,
-                'i': val.data.request_qubit_and_bit_indices_have_same_size,
                 't': [x.serialize() for x in val.data.types]
             }
     else:
@@ -64,8 +63,7 @@ def deserialize(typ, val):
         if 'n' in val:
             return InstructionRef(
                 val['n'],
-                [cqasm.v3x.types.Node.deserialize(x) for x in val['t']],
-                val['i']
+                [cqasm.v3x.types.Node.deserialize(x) for x in val['t']]
             )
         else:
             return InstructionRef()

--- a/res/v3x/parsing/measure_instruction/3_14_to_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/3_14_to_b/ast.golden.txt
@@ -22,23 +22,21 @@ Program(
           size: -
           annotations: []
         )
-        Instruction( # input.cq:5:5..12
+        MeasureInstruction( # input.cq:5:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                FloatLiteral( # input.cq:5:13..17
-                  value: 3.14
-                )
-                Identifier( # input.cq:5:1..2
-                  name: b
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:5:1..2
+              name: b
+            )
+          >
+          rhs: <
+            FloatLiteral( # input.cq:5:13..17
+              value: 3.14
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/3_14_to_b/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/3_14_to_b/semantic.3.0.golden.txt
@@ -1,2 +1,2 @@
 ERROR
-Error at input.cq:5:5..12: failed to resolve overload for measure with argument pack (real, bit)
+Error at input.cq:5:5..12: failed to resolve overload for measure with argument pack (bit, real)

--- a/res/v3x/parsing/measure_instruction/array_of_3_q_to_b0/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_3_q_to_b0/ast.golden.txt
@@ -40,23 +40,21 @@ Program(
           size: -
           annotations: []
         )
-        Instruction( # input.cq:6:6..13
+        MeasureInstruction( # input.cq:6:6..13
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:14..15
-                  name: q
-                )
-                Identifier( # input.cq:6:1..3
-                  name: b0
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:6:1..3
+              name: b0
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:14..15
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/array_of_5_q_to_array_of_5_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_5_q_to_array_of_5_b/ast.golden.txt
@@ -44,23 +44,21 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:13..14
-                  name: q
-                )
-                Identifier( # input.cq:6:1..2
-                  name: b
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:13..14
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/array_of_5_q_to_array_of_5_b/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_5_q_to_array_of_5_b/semantic.3.0.golden.txt
@@ -8,15 +8,15 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
         VariableRef(
           variable --> <
             Variable(
-              name: q
+              name: b
               typ: <
-                QubitArray(
+                BitArray(
                   size: 5
                 )
               >
@@ -27,9 +27,9 @@ Program(
         VariableRef(
           variable --> <
             Variable(
-              name: b
+              name: q
               typ: <
-                BitArray(
+                QubitArray(
                   size: 5
                 )
               >

--- a/res/v3x/parsing/measure_instruction/array_of_5_q_to_array_of_9_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_5_q_to_array_of_9_b/ast.golden.txt
@@ -44,23 +44,21 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:13..14
-                  name: q
-                )
-                Identifier( # input.cq:6:1..2
-                  name: b
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:13..14
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_0_4/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_0_4/ast.golden.txt
@@ -44,45 +44,43 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:10..17
+        MeasureInstruction( # input.cq:6:10..17
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:18..19
-                  name: q
+          lhs: <
+            Index( # input.cq:6:1..2
+              expr: <
+                Identifier(
+                  name: b
                 )
-                Index( # input.cq:6:1..2
-                  expr: <
-                    Identifier(
-                      name: b
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexRange(
-                          first: <
-                            IntegerLiteral( # input.cq:6:3..4
-                              value: 0
-                            )
-                          >
-                          last: <
-                            IntegerLiteral( # input.cq:6:5..6
-                              value: 4
-                            )
-                          >
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexRange(
+                      first: <
+                        IntegerLiteral( # input.cq:6:3..4
+                          value: 0
                         )
-                      ]
+                      >
+                      last: <
+                        IntegerLiteral( # input.cq:6:5..6
+                          value: 4
+                        )
+                      >
                     )
-                  >
+                  ]
                 )
-              ]
+              >
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:18..19
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_0_4/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_0_4/semantic.3.0.golden.txt
@@ -8,22 +8,9 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
-        VariableRef(
-          variable --> <
-            Variable(
-              name: q
-              typ: <
-                QubitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
-        )
         IndexRef(
           variable --> <
             Variable(
@@ -53,6 +40,19 @@ Program(
               value: 4
             )
           ]
+        )
+        VariableRef(
+          variable --> <
+            Variable(
+              name: q
+              typ: <
+                QubitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
         )
       ]
       condition: <

--- a/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_2_6/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_2_6/ast.golden.txt
@@ -44,45 +44,43 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:10..17
+        MeasureInstruction( # input.cq:6:10..17
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:18..19
-                  name: q
+          lhs: <
+            Index( # input.cq:6:1..2
+              expr: <
+                Identifier(
+                  name: b
                 )
-                Index( # input.cq:6:1..2
-                  expr: <
-                    Identifier(
-                      name: b
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexRange(
-                          first: <
-                            IntegerLiteral( # input.cq:6:3..4
-                              value: 2
-                            )
-                          >
-                          last: <
-                            IntegerLiteral( # input.cq:6:5..6
-                              value: 6
-                            )
-                          >
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexRange(
+                      first: <
+                        IntegerLiteral( # input.cq:6:3..4
+                          value: 2
                         )
-                      ]
+                      >
+                      last: <
+                        IntegerLiteral( # input.cq:6:5..6
+                          value: 6
+                        )
+                      >
                     )
-                  >
+                  ]
                 )
-              ]
+              >
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:18..19
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_2_6/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_5_q_to_range_b_2_6/semantic.3.0.golden.txt
@@ -8,22 +8,9 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
-        VariableRef(
-          variable --> <
-            Variable(
-              name: q
-              typ: <
-                QubitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
-        )
         IndexRef(
           variable --> <
             Variable(
@@ -53,6 +40,19 @@ Program(
               value: 6
             )
           ]
+        )
+        VariableRef(
+          variable --> <
+            Variable(
+              name: q
+              typ: <
+                QubitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
         )
       ]
       condition: <

--- a/res/v3x/parsing/measure_instruction/array_of_9_q_to_array_of_5_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/array_of_9_q_to_array_of_5_b/ast.golden.txt
@@ -44,23 +44,21 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:13..14
-                  name: q
-                )
-                Identifier( # input.cq:6:1..2
-                  name: b
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:13..14
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/b_to_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/b_to_b/ast.golden.txt
@@ -22,23 +22,21 @@ Program(
           size: -
           annotations: []
         )
-        Instruction( # input.cq:5:5..12
+        MeasureInstruction( # input.cq:5:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:5:13..14
-                  name: b
-                )
-                Identifier( # input.cq:5:1..2
-                  name: b
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:5:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:5:13..14
+              name: b
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/b_to_q/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/b_to_q/ast.golden.txt
@@ -1,0 +1,62 @@
+SUCCESS
+Program(
+  version: <
+    Version( # input.cq:1:9..10
+      items: 3
+    )
+  >
+  statements: <
+    StatementList(
+      items: [
+        Variables( # input.cq:3:7..8
+          names: [
+            Identifier(
+              name: q
+            )
+          ]
+          typ: <
+            Identifier(
+              name: qubit
+            )
+          >
+          size: -
+          annotations: []
+        )
+        Variables( # input.cq:4:5..6
+          names: [
+            Identifier(
+              name: b
+            )
+          ]
+          typ: <
+            Identifier(
+              name: bit
+            )
+          >
+          size: -
+          annotations: []
+        )
+        MeasureInstruction( # input.cq:6:5..12
+          name: <
+            Identifier(
+              name: measure
+            )
+          >
+          condition: -
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: q
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:13..14
+              name: b
+            )
+          >
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/res/v3x/parsing/measure_instruction/b_to_q/input.cq
+++ b/res/v3x/parsing/measure_instruction/b_to_q/input.cq
@@ -1,0 +1,6 @@
+version 3
+
+qubit q
+bit b
+
+q = measure b

--- a/res/v3x/parsing/measure_instruction/b_to_q/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/b_to_q/semantic.3.0.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:6:5..12: failed to resolve overload for measure with argument pack (qubit, bit)

--- a/res/v3x/parsing/measure_instruction/bit_and_qubit/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/bit_and_qubit/ast.golden.txt
@@ -36,23 +36,21 @@ Program(
           size: -
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:13..14
-                  name: q
-                )
-                Identifier( # input.cq:6:1..2
-                  name: b
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:13..14
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/bit_and_qubit/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/bit_and_qubit/semantic.3.0.golden.txt
@@ -8,15 +8,15 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit, bit)
+      instruction: measure(bit, qubit)
       name: measure
       operands: [
         VariableRef(
           variable --> <
             Variable(
-              name: q
+              name: b
               typ: <
-                Qubit(
+                Bit(
 )
               >
               annotations: []
@@ -26,9 +26,9 @@ Program(
         VariableRef(
           variable --> <
             Variable(
-              name: b
+              name: q
               typ: <
-                Bit(
+                Qubit(
 )
               >
               annotations: []

--- a/res/v3x/parsing/measure_instruction/q0_to_array_of_3_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q0_to_array_of_3_b/ast.golden.txt
@@ -40,23 +40,21 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:13..15
-                  name: q0
-                )
-                Identifier( # input.cq:6:1..2
-                  name: b
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:13..15
+              name: q0
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/q0_to_b_0/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q0_to_b_0/ast.golden.txt
@@ -40,40 +40,38 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:8..15
+        MeasureInstruction( # input.cq:6:8..15
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:6:16..18
-                  name: q0
+          lhs: <
+            Index( # input.cq:6:1..2
+              expr: <
+                Identifier(
+                  name: b
                 )
-                Index( # input.cq:6:1..2
-                  expr: <
-                    Identifier(
-                      name: b
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:3..4
-                              value: 0
-                            )
-                          >
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:3..4
+                          value: 0
                         )
-                      ]
+                      >
                     )
-                  >
+                  ]
                 )
-              ]
+              >
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:6:16..18
+              name: q0
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/q0_to_b_0/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q0_to_b_0/semantic.3.0.golden.txt
@@ -8,21 +8,9 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit, bit array)
+      instruction: measure(bit array, qubit)
       name: measure
       operands: [
-        VariableRef(
-          variable --> <
-            Variable(
-              name: q0
-              typ: <
-                Qubit(
-)
-              >
-              annotations: []
-            )
-          >
-        )
         IndexRef(
           variable --> <
             Variable(
@@ -40,6 +28,18 @@ Program(
               value: 0
             )
           ]
+        )
+        VariableRef(
+          variable --> <
+            Variable(
+              name: q0
+              typ: <
+                Qubit(
+)
+              >
+              annotations: []
+            )
+          >
         )
       ]
       condition: <

--- a/res/v3x/parsing/measure_instruction/q_0_to_b0/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_0_to_b0/ast.golden.txt
@@ -40,40 +40,38 @@ Program(
           size: -
           annotations: []
         )
-        Instruction( # input.cq:6:6..13
+        MeasureInstruction( # input.cq:6:6..13
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Index( # input.cq:6:14..15
-                  expr: <
-                    Identifier(
-                      name: q
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:16..17
-                              value: 0
-                            )
-                          >
+          lhs: <
+            Identifier( # input.cq:6:1..3
+              name: b0
+            )
+          >
+          rhs: <
+            Index( # input.cq:6:14..15
+              expr: <
+                Identifier(
+                  name: q
+                )
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:16..17
+                          value: 0
                         )
-                      ]
+                      >
                     )
-                  >
+                  ]
                 )
-                Identifier( # input.cq:6:1..3
-                  name: b0
-                )
-              ]
+              >
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/q_0_to_b0/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_0_to_b0/semantic.3.0.golden.txt
@@ -8,9 +8,21 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit)
+      instruction: measure(bit, qubit array)
       name: measure
       operands: [
+        VariableRef(
+          variable --> <
+            Variable(
+              name: b0
+              typ: <
+                Bit(
+)
+              >
+              annotations: []
+            )
+          >
+        )
         IndexRef(
           variable --> <
             Variable(
@@ -28,18 +40,6 @@ Program(
               value: 0
             )
           ]
-        )
-        VariableRef(
-          variable --> <
-            Variable(
-              name: b0
-              typ: <
-                Bit(
-)
-              >
-              annotations: []
-            )
-          >
         )
       ]
       condition: <

--- a/res/v3x/parsing/measure_instruction/q_1_3_4_5_7_to_array_of_5_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_1_3_4_5_7_to_array_of_5_b/ast.golden.txt
@@ -44,68 +44,66 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Index( # input.cq:6:13..14
-                  expr: <
-                    Identifier(
-                      name: q
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:15..16
-                              value: 1
-                            )
-                          >
-                        )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:18..19
-                              value: 3
-                            )
-                          >
-                        )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:21..22
-                              value: 4
-                            )
-                          >
-                        )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:24..25
-                              value: 5
-                            )
-                          >
-                        )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:27..28
-                              value: 7
-                            )
-                          >
-                        )
-                      ]
-                    )
-                  >
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Index( # input.cq:6:13..14
+              expr: <
+                Identifier(
+                  name: q
                 )
-                Identifier( # input.cq:6:1..2
-                  name: b
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:15..16
+                          value: 1
+                        )
+                      >
+                    )
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:18..19
+                          value: 3
+                        )
+                      >
+                    )
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:21..22
+                          value: 4
+                        )
+                      >
+                    )
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:24..25
+                          value: 5
+                        )
+                      >
+                    )
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:27..28
+                          value: 7
+                        )
+                      >
+                    )
+                  ]
                 )
-              ]
+              >
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/q_1_3_4_5_7_to_array_of_5_b/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_1_3_4_5_7_to_array_of_5_b/semantic.3.0.golden.txt
@@ -8,9 +8,22 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
+        VariableRef(
+          variable --> <
+            Variable(
+              name: b
+              typ: <
+                BitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
+        )
         IndexRef(
           variable --> <
             Variable(
@@ -40,19 +53,6 @@ Program(
               value: 7
             )
           ]
-        )
-        VariableRef(
-          variable --> <
-            Variable(
-              name: b
-              typ: <
-                BitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
         )
       ]
       condition: <

--- a/res/v3x/parsing/measure_instruction/q_2_4_to_b_1_3/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_2_4_to_b_1_3/ast.golden.txt
@@ -44,71 +44,69 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:11..18
+        MeasureInstruction( # input.cq:6:11..18
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Index( # input.cq:6:19..20
-                  expr: <
-                    Identifier(
-                      name: q
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:21..22
-                              value: 2
-                            )
-                          >
-                        )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:24..25
-                              value: 4
-                            )
-                          >
-                        )
-                      ]
-                    )
-                  >
+          lhs: <
+            Index( # input.cq:6:1..2
+              expr: <
+                Identifier(
+                  name: b
                 )
-                Index( # input.cq:6:1..2
-                  expr: <
-                    Identifier(
-                      name: b
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:3..4
-                              value: 1
-                            )
-                          >
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:3..4
+                          value: 1
                         )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:6..7
-                              value: 3
-                            )
-                          >
-                        )
-                      ]
+                      >
                     )
-                  >
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:6..7
+                          value: 3
+                        )
+                      >
+                    )
+                  ]
                 )
-              ]
+              >
+            )
+          >
+          rhs: <
+            Index( # input.cq:6:19..20
+              expr: <
+                Identifier(
+                  name: q
+                )
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:21..22
+                          value: 2
+                        )
+                      >
+                    )
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:24..25
+                          value: 4
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/q_2_4_to_b_1_3/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_2_4_to_b_1_3/semantic.3.0.golden.txt
@@ -8,30 +8,9 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
-        IndexRef(
-          variable --> <
-            Variable(
-              name: q
-              typ: <
-                QubitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
-          indices: [
-            ConstInt(
-              value: 2
-            )
-            ConstInt(
-              value: 4
-            )
-          ]
-        )
         IndexRef(
           variable --> <
             Variable(
@@ -50,6 +29,27 @@ Program(
             )
             ConstInt(
               value: 3
+            )
+          ]
+        )
+        IndexRef(
+          variable --> <
+            Variable(
+              name: q
+              typ: <
+                QubitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
+          indices: [
+            ConstInt(
+              value: 2
+            )
+            ConstInt(
+              value: 4
             )
           ]
         )

--- a/res/v3x/parsing/measure_instruction/q_2_4_to_range_b_1_2/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_2_4_to_range_b_1_2/ast.golden.txt
@@ -44,69 +44,67 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:10..17
+        MeasureInstruction( # input.cq:6:10..17
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Index( # input.cq:6:18..19
-                  expr: <
-                    Identifier(
-                      name: q
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:20..21
-                              value: 2
-                            )
-                          >
-                        )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:23..24
-                              value: 4
-                            )
-                          >
-                        )
-                      ]
-                    )
-                  >
+          lhs: <
+            Index( # input.cq:6:1..2
+              expr: <
+                Identifier(
+                  name: b
                 )
-                Index( # input.cq:6:1..2
-                  expr: <
-                    Identifier(
-                      name: b
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexRange(
-                          first: <
-                            IntegerLiteral( # input.cq:6:3..4
-                              value: 1
-                            )
-                          >
-                          last: <
-                            IntegerLiteral( # input.cq:6:5..6
-                              value: 2
-                            )
-                          >
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexRange(
+                      first: <
+                        IntegerLiteral( # input.cq:6:3..4
+                          value: 1
                         )
-                      ]
+                      >
+                      last: <
+                        IntegerLiteral( # input.cq:6:5..6
+                          value: 2
+                        )
+                      >
                     )
-                  >
+                  ]
                 )
-              ]
+              >
+            )
+          >
+          rhs: <
+            Index( # input.cq:6:18..19
+              expr: <
+                Identifier(
+                  name: q
+                )
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:20..21
+                          value: 2
+                        )
+                      >
+                    )
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:23..24
+                          value: 4
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/q_2_4_to_range_b_1_2/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_2_4_to_range_b_1_2/semantic.3.0.golden.txt
@@ -8,30 +8,9 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
-        IndexRef(
-          variable --> <
-            Variable(
-              name: q
-              typ: <
-                QubitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
-          indices: [
-            ConstInt(
-              value: 2
-            )
-            ConstInt(
-              value: 4
-            )
-          ]
-        )
         IndexRef(
           variable --> <
             Variable(
@@ -50,6 +29,27 @@ Program(
             )
             ConstInt(
               value: 2
+            )
+          ]
+        )
+        IndexRef(
+          variable --> <
+            Variable(
+              name: q
+              typ: <
+                QubitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
+          indices: [
+            ConstInt(
+              value: 2
+            )
+            ConstInt(
+              value: 4
             )
           ]
         )

--- a/res/v3x/parsing/measure_instruction/q_to_5/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_to_5/ast.golden.txt
@@ -22,23 +22,21 @@ Program(
           size: -
           annotations: []
         )
-        Instruction( # input.cq:5:5..12
+        MeasureInstruction( # input.cq:5:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:5:13..14
-                  name: q
-                )
-                IntegerLiteral( # input.cq:5:1..2
-                  value: 5
-                )
-              ]
+          lhs: <
+            IntegerLiteral( # input.cq:5:1..2
+              value: 5
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:5:13..14
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/q_to_5/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_to_5/semantic.3.0.golden.txt
@@ -1,2 +1,2 @@
 ERROR
-Error at input.cq:5:5..12: failed to resolve overload for measure with argument pack (qubit, int)
+Error at input.cq:5:5..12: failed to resolve overload for measure with argument pack (int, qubit)

--- a/res/v3x/parsing/measure_instruction/q_to_q/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/q_to_q/ast.golden.txt
@@ -22,23 +22,21 @@ Program(
           size: -
           annotations: []
         )
-        Instruction( # input.cq:5:5..12
+        MeasureInstruction( # input.cq:5:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Identifier( # input.cq:5:13..14
-                  name: q
-                )
-                Identifier( # input.cq:5:1..2
-                  name: q
-                )
-              ]
+          lhs: <
+            Identifier( # input.cq:5:1..2
+              name: q
+            )
+          >
+          rhs: <
+            Identifier( # input.cq:5:13..14
+              name: q
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/range_q_0_4_to_array_of_5_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/range_q_0_4_to_array_of_5_b/ast.golden.txt
@@ -44,45 +44,43 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Index( # input.cq:6:13..14
-                  expr: <
-                    Identifier(
-                      name: q
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexRange(
-                          first: <
-                            IntegerLiteral( # input.cq:6:15..16
-                              value: 0
-                            )
-                          >
-                          last: <
-                            IntegerLiteral( # input.cq:6:17..18
-                              value: 4
-                            )
-                          >
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Index( # input.cq:6:13..14
+              expr: <
+                Identifier(
+                  name: q
+                )
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexRange(
+                      first: <
+                        IntegerLiteral( # input.cq:6:15..16
+                          value: 0
                         )
-                      ]
+                      >
+                      last: <
+                        IntegerLiteral( # input.cq:6:17..18
+                          value: 4
+                        )
+                      >
                     )
-                  >
+                  ]
                 )
-                Identifier( # input.cq:6:1..2
-                  name: b
-                )
-              ]
+              >
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/range_q_0_4_to_array_of_5_b/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/range_q_0_4_to_array_of_5_b/semantic.3.0.golden.txt
@@ -8,9 +8,22 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
+        VariableRef(
+          variable --> <
+            Variable(
+              name: b
+              typ: <
+                BitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
+        )
         IndexRef(
           variable --> <
             Variable(
@@ -40,19 +53,6 @@ Program(
               value: 4
             )
           ]
-        )
-        VariableRef(
-          variable --> <
-            Variable(
-              name: b
-              typ: <
-                BitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
         )
       ]
       condition: <

--- a/res/v3x/parsing/measure_instruction/range_q_2_6_to_array_of_5_b/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/range_q_2_6_to_array_of_5_b/ast.golden.txt
@@ -44,45 +44,43 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:5..12
+        MeasureInstruction( # input.cq:6:5..12
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Index( # input.cq:6:13..14
-                  expr: <
-                    Identifier(
-                      name: q
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexRange(
-                          first: <
-                            IntegerLiteral( # input.cq:6:15..16
-                              value: 2
-                            )
-                          >
-                          last: <
-                            IntegerLiteral( # input.cq:6:17..18
-                              value: 6
-                            )
-                          >
+          lhs: <
+            Identifier( # input.cq:6:1..2
+              name: b
+            )
+          >
+          rhs: <
+            Index( # input.cq:6:13..14
+              expr: <
+                Identifier(
+                  name: q
+                )
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexRange(
+                      first: <
+                        IntegerLiteral( # input.cq:6:15..16
+                          value: 2
                         )
-                      ]
+                      >
+                      last: <
+                        IntegerLiteral( # input.cq:6:17..18
+                          value: 6
+                        )
+                      >
                     )
-                  >
+                  ]
                 )
-                Identifier( # input.cq:6:1..2
-                  name: b
-                )
-              ]
+              >
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/range_q_2_6_to_array_of_5_b/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/range_q_2_6_to_array_of_5_b/semantic.3.0.golden.txt
@@ -8,9 +8,22 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
+        VariableRef(
+          variable --> <
+            Variable(
+              name: b
+              typ: <
+                BitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
+        )
         IndexRef(
           variable --> <
             Variable(
@@ -40,19 +53,6 @@ Program(
               value: 6
             )
           ]
-        )
-        VariableRef(
-          variable --> <
-            Variable(
-              name: b
-              typ: <
-                BitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
         )
       ]
       condition: <

--- a/res/v3x/parsing/measure_instruction/range_q_3_4_to_b_1_3/ast.golden.txt
+++ b/res/v3x/parsing/measure_instruction/range_q_3_4_to_b_1_3/ast.golden.txt
@@ -44,69 +44,67 @@ Program(
           >
           annotations: []
         )
-        Instruction( # input.cq:6:11..18
+        MeasureInstruction( # input.cq:6:11..18
           name: <
             Identifier(
               name: measure
             )
           >
           condition: -
-          operands: <
-            ExpressionList(
-              items: [
-                Index( # input.cq:6:19..20
-                  expr: <
-                    Identifier(
-                      name: q
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexRange(
-                          first: <
-                            IntegerLiteral( # input.cq:6:21..22
-                              value: 3
-                            )
-                          >
-                          last: <
-                            IntegerLiteral( # input.cq:6:23..24
-                              value: 4
-                            )
-                          >
-                        )
-                      ]
-                    )
-                  >
+          lhs: <
+            Index( # input.cq:6:1..2
+              expr: <
+                Identifier(
+                  name: b
                 )
-                Index( # input.cq:6:1..2
-                  expr: <
-                    Identifier(
-                      name: b
-                    )
-                  >
-                  indices: <
-                    IndexList(
-                      items: [
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:3..4
-                              value: 1
-                            )
-                          >
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:3..4
+                          value: 1
                         )
-                        IndexItem(
-                          index: <
-                            IntegerLiteral( # input.cq:6:6..7
-                              value: 3
-                            )
-                          >
-                        )
-                      ]
+                      >
                     )
-                  >
+                    IndexItem(
+                      index: <
+                        IntegerLiteral( # input.cq:6:6..7
+                          value: 3
+                        )
+                      >
+                    )
+                  ]
                 )
-              ]
+              >
+            )
+          >
+          rhs: <
+            Index( # input.cq:6:19..20
+              expr: <
+                Identifier(
+                  name: q
+                )
+              >
+              indices: <
+                IndexList(
+                  items: [
+                    IndexRange(
+                      first: <
+                        IntegerLiteral( # input.cq:6:21..22
+                          value: 3
+                        )
+                      >
+                      last: <
+                        IntegerLiteral( # input.cq:6:23..24
+                          value: 4
+                        )
+                      >
+                    )
+                  ]
+                )
+              >
             )
           >
           annotations: []

--- a/res/v3x/parsing/measure_instruction/range_q_3_4_to_b_1_3/semantic.3.0.golden.txt
+++ b/res/v3x/parsing/measure_instruction/range_q_3_4_to_b_1_3/semantic.3.0.golden.txt
@@ -8,30 +8,9 @@ Program(
   >
   statements: [
     Instruction(
-      instruction: measure(qubit array, bit array)
+      instruction: measure(bit array, qubit array)
       name: measure
       operands: [
-        IndexRef(
-          variable --> <
-            Variable(
-              name: q
-              typ: <
-                QubitArray(
-                  size: 5
-                )
-              >
-              annotations: []
-            )
-          >
-          indices: [
-            ConstInt(
-              value: 3
-            )
-            ConstInt(
-              value: 4
-            )
-          ]
-        )
         IndexRef(
           variable --> <
             Variable(
@@ -50,6 +29,27 @@ Program(
             )
             ConstInt(
               value: 3
+            )
+          ]
+        )
+        IndexRef(
+          variable --> <
+            Variable(
+              name: q
+              typ: <
+                QubitArray(
+                  size: 5
+                )
+              >
+              annotations: []
+            )
+          >
+          indices: [
+            ConstInt(
+              value: 3
+            )
+            ConstInt(
+              value: 4
             )
           ]
         )

--- a/src/v3x/BuildTreeGenAstVisitor.cpp
+++ b/src/v3x/BuildTreeGenAstVisitor.cpp
@@ -144,12 +144,11 @@ std::any BuildTreeGenAstVisitor::visitBitTypeDefinition(CqasmParser::BitTypeDefi
 }
 
 std::any BuildTreeGenAstVisitor::visitMeasureInstruction(CqasmParser::MeasureInstructionContext *context) {
-    auto ret = cqasm::tree::make<Instruction>();
+    auto ret = cqasm::tree::make<MeasureInstruction>();
     ret->name = cqasm::tree::make<Identifier>(context->MEASURE()->getText());
     ret->condition = cqasm::tree::Maybe<Expression>{};
-    ret->operands = cqasm::tree::make<ExpressionList>();
-    ret->operands->items.add(std::any_cast<One<Expression>>(context->expression(1)->accept(this)));
-    ret->operands->items.add(std::any_cast<One<Expression>>(context->expression(0)->accept(this)));
+    ret->lhs = std::any_cast<One<Expression>>(context->expression(0)->accept(this));
+    ret->rhs = std::any_cast<One<Expression>>(context->expression(1)->accept(this));
     const auto &token = context->MEASURE()->getSymbol();
     setNodeAnnotation(ret, token);
     return One<Statement>{ ret };

--- a/src/v3x/cqasm-analyzer.cpp
+++ b/src/v3x/cqasm-analyzer.cpp
@@ -68,10 +68,9 @@ void Analyzer::register_instruction(const instruction::Instruction &instruction)
  * Convenience method for registering an instruction type. The arguments
  * are passed straight to instruction::Instruction's constructor.
  */
-void Analyzer::register_instruction(const std::string &name, const std::string &param_types,
-    bool request_qubit_and_bit_indices_have_same_size) {
+void Analyzer::register_instruction(const std::string &name, const std::string &param_types) {
 
-    register_instruction(instruction::Instruction(name, param_types, request_qubit_and_bit_indices_have_same_size));
+    register_instruction(instruction::Instruction(name, param_types));
 }
 
 /**

--- a/src/v3x/cqasm-ast.tree
+++ b/src/v3x/cqasm-ast.tree
@@ -85,12 +85,6 @@ annotated {
     annotations: Any<annotation_data>;
 
     statement {
-        # A mapping (alias) for an expression.
-        mapping {
-            alias: One<identifier>;
-            expr: One<expression>;
-        }
-
         # One or more variable declarations of some type.
         variables {
             names: Many<identifier>;

--- a/src/v3x/cqasm-ast.tree
+++ b/src/v3x/cqasm-ast.tree
@@ -99,10 +99,23 @@ annotated {
         }
 
         # A gate.
-        instruction {
-            name: One<identifier>;
-            condition: Maybe<expression>;
-            operands: One<expression_list>;
+        instruction_base {
+            instruction {
+                name: One<identifier>;
+                condition: Maybe<expression>;
+                operands: One<expression_list>;
+            }
+
+            # For some instructions, like the measure instruction,
+            # we want to differentiate between left hand side and right and side operands.
+            # For a measure instruction, the right hand side operand should be a qubit,
+            # and the left hand side operand a bit.
+            measure_instruction {
+                name: One<identifier>;
+                condition: Maybe<expression>;
+                lhs: One<expression>;
+                rhs: One<expression>;
+            }
         }
     }
 }

--- a/src/v3x/cqasm-instruction.cpp
+++ b/src/v3x/cqasm-instruction.cpp
@@ -15,13 +15,9 @@ namespace instruction {
  * param_types is a shorthand type specification string as parsed by cqasm::types::from_spec().
  * If you need more control, you can also manipulate param_types directly.
  */
-Instruction::Instruction(
-    const std::string &name,
-    const std::string &param_types,
-    bool request_qubit_and_bit_indices_have_same_size)
+Instruction::Instruction(const std::string &name, const std::string &param_types)
 : name{ name }
 , param_types{ types::from_spec(param_types) }
-, request_qubit_and_bit_indices_have_same_size{ request_qubit_and_bit_indices_have_same_size }
 {}
 
 /**
@@ -58,7 +54,6 @@ void serialize(const instruction::InstructionRef &obj, ::tree::cbor::MapWriter &
         return;
     }
     map.append_string("n", obj->name);
-    map.append_bool("i", obj->request_qubit_and_bit_indices_have_same_size);
     auto aw = map.append_array("t");
     for (const auto &t : obj->param_types) {
         aw.append_binary(::tree::base::serialize(t));
@@ -71,11 +66,7 @@ instruction::InstructionRef deserialize(const ::tree::cbor::MapReader &map) {
     if (!map.count("n")) {
         return {};
     }
-    auto insn = tree::make<instruction::Instruction>(
-        map.at("n").as_string(),
-        "",
-        map.at("f").as_bool()
-    );
+    auto insn = tree::make<instruction::Instruction>(map.at("n").as_string(), "");
     auto ar = map.at("t").as_array();
     for (const auto &element : ar) {
         insn->param_types.add(::tree::base::deserialize<types::Node>(element.as_binary()));

--- a/src/v3x/cqasm-py.cpp
+++ b/src/v3x/cqasm-py.cpp
@@ -34,16 +34,8 @@ V3xAnalyzer::V3xAnalyzer(const std::string &max_version, bool without_defaults) 
  * Registers an instruction type.
  * The arguments are passed straight to instruction::Instruction's constructor.
  */
-void V3xAnalyzer::register_instruction(
-    const std::string &name,
-    const std::string &param_types,
-    bool request_qubit_and_bit_indices_have_same_size
-) {
-    a->register_instruction(
-        name,
-        param_types,
-        request_qubit_and_bit_indices_have_same_size
-    );
+void V3xAnalyzer::register_instruction(const std::string &name, const std::string &param_types) {
+    a->register_instruction(name, param_types);
 }
 
 /**

--- a/test/v3x/parsing.cpp
+++ b/test/v3x/parsing.cpp
@@ -66,10 +66,10 @@ public:
             analyzer.register_instruction("h", "Q");
             analyzer.register_instruction("h", "V");
             analyzer.register_instruction("i", "Q");
-            analyzer.register_instruction("measure", "QB", true);  // qubit - bit
-            analyzer.register_instruction("measure", "VW", true);  // qubit array - bit array
-            analyzer.register_instruction("measure", "VB", true);  // qubit array - bit
-            analyzer.register_instruction("measure", "QW", true);  // qubit - bit array
+            analyzer.register_instruction("measure", "BQ");  // bit = qubit
+            analyzer.register_instruction("measure", "WV");  // bit array = qubit array
+            analyzer.register_instruction("measure", "BV");  // bit = qubit array
+            analyzer.register_instruction("measure", "WQ");  // bit array = qubit
             analyzer.register_instruction("mx90", "Q");
             analyzer.register_instruction("my90", "Q");
             analyzer.register_instruction("rx", "Qr");


### PR DESCRIPTION
Added an `instruction_base` class to the tree-gen syntactic AST.
This class serves as a base class for `instruction` and `measure_instruction`.
A `measure_instruction` has a `lhs` operand, and a `rhs` operand.
The names have been chosen to be similar to v1x assignment instructions.
A measure instruction is kind of an assignment from qubits to bits, with a left hand side expression and a right hand side expression.
These operands can be multi-index, but not lists of expressions.
The current instruction resolver cannot deal yet with instructions accepting a variadic list of arguments.

Removed `request_qubit_and_bit_indices_have_same_size` member from `Instruction`.
This check is now implicit for a measure instruction.

`parsing.cpp`:
- Updated parameter order when registering a measure instruction.
- The order is now left to right, bit to qubit.