### PR TITLE
One single version of truth

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -9,9 +9,12 @@ from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake
 from conan.tools.files import copy
 from conan.tools.scm import Version
 
+from version import get_version
+
 
 class LibqasmConan(ConanFile):
     name = "libqasm"
+    version = get_version()
 
     # Optional metadata
     license = "Apache-2.0"
@@ -47,6 +50,7 @@ class LibqasmConan(ConanFile):
         "tree_gen_build_tests": False
     }
 
+    exports = "version.py", "include/version.hpp"
     exports_sources = "CMakeLists.txt", "include/*", "python/*", "res/*", "scripts/*", "src/*", "test/*"
 
     def build_requirements(self):

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#define LIBQASM_VERSION "0.4.1"
+#define LIBQASM_RELEASE_YEAR "2023"

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import os
 import platform
 import re
 import shutil
+
 from distutils.dir_util import copy_tree
 from setuptools import setup, Extension
 
@@ -15,6 +16,8 @@ from distutils.command.bdist import bdist as _bdist
 from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
 from distutils.command.sdist import sdist as _sdist
 from setuptools.command.egg_info import egg_info as _egg_info
+
+from version import get_version
 
 root_dir = os.getcwd()  # root of the repository
 src_dir = root_dir + os.sep + 'src'  # C++ source directory
@@ -34,10 +37,6 @@ module_dir = target_dir + os.sep + 'module'  # libQasm Python module directory, 
 if not os.path.exists(target_dir):
     os.makedirs(target_dir)
 copy_tree(srcmod_dir, module_dir)
-
-
-def get_version():
-    return '0.4.1'
 
 
 def read(file_name):
@@ -89,7 +88,7 @@ class build_ext(_build_ext):
             cmd & FG
 
             cmd = (local['conan']['create']['.']
-                ['--version']['0.4.1']
+                ['--version'][get_version()]
                 ['-s:h']['compiler.cppstd=20']
                 ['-s:h']["libqasm/*:build_type=" + build_type]
 

--- a/version.py
+++ b/version.py
@@ -1,0 +1,22 @@
+import os
+import re
+
+
+def get_version(verbose=0):
+    """Extract version information from source code"""
+
+    root_dir = os.getcwd()  # root of the repository
+    inc_dir = root_dir + os.sep + "include"  # C++ include directory
+    matcher = re.compile('[\t ]*#define[\t ]+LIBQASM_VERSION[\t ]+"(.*)"')
+    version = None
+    with open(os.path.join(inc_dir, "version.hpp"), "r") as f:
+        for ln in f:
+            m = matcher.match(ln)
+            if m:
+                version = m.group(1)
+                break
+
+    if verbose:
+        print("get_version: %s" % version)
+
+    return version

--- a/version.py
+++ b/version.py
@@ -2,7 +2,7 @@ import os
 import re
 
 
-def get_version(verbose=0):
+def get_version(verbose=False):
     """Extract version information from source code"""
 
     root_dir = os.getcwd()  # root of the repository


### PR DESCRIPTION
Added `include/version.hpp` to define `libqasm` version in a single place.
Then made this definition available to Python code through the `get_version` method at `version.py`.
And used this method from `setup.py`.

This is very similar to what is done at the moment for the QX simulator.
The main difference is that I've put the implementation of the get_version method in a `version.py` file.
I've done this because I think that, in the future, it may be needed to access this `get_version` method from `conanfile.py`.