### PR TITLE
Remove msvc-runtime Python Windows dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -214,7 +214,6 @@ setup(
         'delocate; platform_system == "Darwin"',
     ],
     install_requires=[
-        'msvc-runtime; platform_system == "Windows"',
         'numpy'
     ],
     tests_require=[


### PR DESCRIPTION
This package doesn't seem well maintained and libqasm works fine on Windows without. Moreover, it's creating issues with Python 3.12 (impossible to install libqasm).