### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ 0.5.2 ] - [ 2024-01-18 ]
+
+### Added
+- Variable declaration and initialization in cqasm v3 parser
+- New types in v3: bool, int, float, axis
+- Arrays in v3
+
+### Changed
+
+- v3x::AnalyzeTreeGenAstVisitor is an instance of tree-gen generated visitor base class
+
+### Removed
+
+- msvc-runtime pip dependency on Windows
+
 ## [ 0.5.1 ] - [ 2024-01-08 ]
 
 ### Added

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,4 +1,4 @@
 #pragma once
 
-#define LIBQASM_VERSION "0.5.1"
+#define LIBQASM_VERSION "0.5.2"
 #define LIBQASM_RELEASE_YEAR "2024"


### PR DESCRIPTION

### Added
- Variable declaration and initialization in cqasm v3 parser
- New types in v3: bool, int, float, axis
- Arrays in v3

### Changed

- v3x::AnalyzeTreeGenAstVisitor is an instance of tree-gen generated visitor base class

### Removed

- msvc-runtime pip dependency on Windows
