### PR TITLE
Fix Python primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,11 +88,6 @@ log
 # SWIG generated sources
 library/**/*_swig*
 
-.idea/
-cmake-build-*/
-
-tags
-
 # IDE's
 .project
 .cproject
@@ -105,3 +100,28 @@ conan.lock
 conanbuildinfo.txt
 conaninfo.txt
 graph_info.json
+conan_host_profile
+conan_provider.cmake
+
+# res
+ast.actual.txt
+ast.actual.json
+semantic.3.0.actual.txt
+semantic.3.0.actual.json
+
+*/*/CMakeFiles
+*/CMakeFiles/
+.idea/
+CMakeFiles/
+CTestTestfile.cmake
+Changes.patch
+DartConfiguration.tcl
+Makefile
+cmake-build-*/
+cmake_install.cmake
+src/*.cmake
+src/*/*.cmake
+tags
+test/*.cmake
+test/v3x/*.cmake
+test/v3x/cpp/*.cmake

--- a/python/module/cqasm/v3x/primitives.py
+++ b/python/module/cqasm/v3x/primitives.py
@@ -4,21 +4,8 @@ import cqasm.v3x.types
 Str = str
 Bool = bool
 Int = int
-Real = float
+Float = float
 Complex = complex
-
-
-class Axis:
-
-    def __init__(self):
-        self._x = 1.0
-        self._y = 0.0
-        self._z = 0.0
-
-    def __init__(self, x, y, z):
-        self._x = x
-        self._y = y
-        self._z = z
 
 
 class Version(tuple):
@@ -39,12 +26,8 @@ def serialize(typ, val):
         return {'x': val}
     elif typ is Int:
         return {'x': val}
-    elif typ is Real:
+    elif typ is Float:
         return {'x': val}
-    elif typ is Complex:
-        return {'r': val.real, 'i': val.imag}
-    elif typ is Axis:
-        return {'x': val.x, 'y': val.y, 'z': val.z}
     elif typ is Version:
         return {'x': list(val)}
     elif typ is cqasm.v3x.instruction.InstructionRef:
@@ -68,12 +51,8 @@ def deserialize(typ, val):
         return Bool(val['x'])
     elif typ is Int:
         return Int(val['x'])
-    elif typ is Real:
-        return Real(val['x'])
-    elif typ is Complex:
-        return Complex(val['r'], val['i'])
-    elif typ is Axis:
-        return Axis(val['x'], val['y'], val['z'])
+    elif typ is Float:
+        return Float(val['x'])
     elif typ is Version:
         return Version(val['x'])
     elif typ is cqasm.v3x.instruction.InstructionRef:


### PR DESCRIPTION
`python/module/cqasm/v3x/primitives.py` still contains references to `Real` type, which is now called `Float`.