### PR TITLE
Changes requested for libqasm Conan package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [ 0.6.4 ] - [ 2024-04-15 ]
+
+### Added
+
+### Changed
+
+- Fixed CMake install.
+- `generate_antlr_parser.py` writes output include files in a given `include` folder. 
+
+### Removed
+
 ## [ 0.6.3 ] - [ 2024-04-12 ]
 
 ### Added
@@ -14,7 +25,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Allow multiple `measure` instructions at the end of a program.
 
 ### Removed
-
 
 ## [ 0.6.2 ] - [ 2024-04-09 ]
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -52,7 +52,7 @@ class LibqasmConan(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("tree-gen/1.0.7")
-        self.tool_requires("zulu-openjdk/11.0.19")
+        self.tool_requires("zulu-openjdk/21.0.1")
         if self.settings.arch == "wasm":
             self.tool_requires("emsdk/3.1.50")
         if self.options.build_tests:

--- a/emscripten/test_cqasm.js
+++ b/emscripten/test_cqasm.js
@@ -12,7 +12,7 @@ wrapper().then(function(result) {
 
     try {
         var output = cqasm.get_version()
-        var expected_output = "0.6.3"
+        var expected_output = "0.6.4"
         console.log("\nThe version of libqasm compiled with emscripten is:", output);
         if (output !== expected_output) {
             console.log("\tExpected output:", expected_output)

--- a/include/v3x/cqasm-types.hpp
+++ b/include/v3x/cqasm-types.hpp
@@ -16,17 +16,10 @@
 namespace cqasm::v3x::types {
 
 constexpr const char *qubit_type_name = "qubit";
-constexpr const char *bit_type_name = "bit";
-constexpr const char *axis_type_name = "axis";
 constexpr const char *bool_type_name = "bool";
 constexpr const char *integer_type_name = "int";
 constexpr const char *float_type_name = "float";
-constexpr const char *complex_type_name = "complex";
 constexpr const char *qubit_array_type_name = "qubit array";
-constexpr const char *bit_array_type_name = "bit array";
-constexpr const char *bool_array_type_name = "bool array";
-constexpr const char *integer_array_type_name = "int array";
-constexpr const char *float_array_type_name = "float array";
 
 /**
  * A cQASM type.

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -2,7 +2,7 @@
 
 namespace cqasm {
 
-static const char *version{ "0.6.3" };
+static const char *version{ "0.6.4" };
 static const char *release_year{ "2024" };
 
 [[nodiscard]] [[maybe_unused]] static const char *get_version() {

--- a/scripts/generate_antlr_parser.py
+++ b/scripts/generate_antlr_parser.py
@@ -71,8 +71,10 @@ def generate_antlr_parser(input_folder, output_source_folder, output_include_fol
             exit(5)
         # Move header files to output include folder
         output_files = os.listdir(output_source_folder)
+        print(f"Moving output include files to {output_include_folder}")
         for output_file in output_files:
             if output_file.endswith(".h"):
+                print(f"\t{output_file}")
                 shutil.move(os.path.join(output_source_folder, output_file), output_include_folder)
     except FileNotFoundError as err:
         print("Error running java: {}".format(err.strerror))

--- a/scripts/generate_antlr_parser.py
+++ b/scripts/generate_antlr_parser.py
@@ -4,18 +4,20 @@ from urllib.request import urlopen
 from urllib import error
 
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
 
 
 def print_usage():
-    print("Usage: generate_antlr_parser.py <INPUT FOLDER> <OUTPUT FOLDER>")
+    print("Usage: generate_antlr_parser.py <INPUT FOLDER> <OUTPUT SOURCE FOLDER> <OUTPUT INCLUDE FOLDER>")
     print("Where:")
     print("    INPUT_FOLDER: folder containing the grammar files.")
-    print("    OUTPUT_FOLDER: folder where generated files will be left.")
+    print("    OUTPUT_SOURCE_FOLDER: folder where generated source files will be left.")
+    print("    OUTPUT_INCLUDE_FOLDER: folder where generated include files will be left.")
     print("Example:")
-    print("    generate_antlr_parser.py ../src/v3x ../build/Debug/src/v3x")
+    print("    generate_antlr_parser.py ../src/v3x ../build/Debug/src/v3x ../build/Debug/include/v3x")
 
 
 class AntlrJarFileDownloader:
@@ -47,7 +49,7 @@ class AntlrJarFileDownloader:
         return cls.file_path
 
 
-def generate_antlr_parser(input_folder, output_folder, antlr_jar_file_path):
+def generate_antlr_parser(input_folder, output_source_folder, output_include_folder, antlr_jar_file_path):
     print("Generating ANTLR lexer and parser files")
     try:
         completed_process = subprocess.run([
@@ -58,7 +60,7 @@ def generate_antlr_parser(input_folder, output_folder, antlr_jar_file_path):
             "-visitor",
             "-Xexact-output-dir",
             "-o",
-            "{}".format(output_folder),
+            "{}".format(output_source_folder),
             "-Dlanguage=Cpp",
             "-Werror",
             "{}/CqasmLexer.g4".format(input_folder),
@@ -67,16 +69,21 @@ def generate_antlr_parser(input_folder, output_folder, antlr_jar_file_path):
         if completed_process.returncode != 0:
             print("Error generating ANTLR lexer and parser files: {}", completed_process.returncode)
             exit(5)
+        # Move header files to output include folder
+        output_files = os.listdir(output_source_folder)
+        for output_file in output_files:
+            if output_file.endswith(".h"):
+                shutil.move(os.path.join(output_source_folder, output_file), output_include_folder)
     except FileNotFoundError as err:
         print("Error running java: {}".format(err.strerror))
         exit(4)
 
 
 def main(argv):
-    if len(argv) != 3:
+    if len(argv) != 4:
         print_usage()
         exit(2)
-    generate_antlr_parser(argv[1], argv[2], AntlrJarFileDownloader.get_antlr_jar_file_path())
+    generate_antlr_parser(argv[1], argv[2], argv[3], AntlrJarFileDownloader.get_antlr_jar_file_path())
 
 
 if __name__ == '__main__':

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -109,10 +109,10 @@ set(CQASM_COMMON_SOURCES
 add_subdirectory(v3x)
 
 # Generate the lexer and the parser.
-function(antlr_target SCRIPT INPUT_DIR OUTPUT_DIR ANTLR_OUTPUTS)
+function(antlr_target SCRIPT INPUT_DIR OUTPUT_SRC_DIR OUTPUT_INC_DIR ANTLR_OUTPUTS)
     add_custom_command(
         OUTPUT ${ANTLR_OUTPUTS}
-        COMMAND ${Python3_EXECUTABLE} ${SCRIPT} ${INPUT_DIR} ${OUTPUT_DIR}
+        COMMAND ${Python3_EXECUTABLE} ${SCRIPT} ${INPUT_DIR} ${OUTPUT_SRC_DIR} ${OUTPUT_INC_DIR}
     )
 endfunction()
 
@@ -220,6 +220,7 @@ target_include_directories(cqasm-lib-obj
     PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/"
     PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/../include/"
     PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/../include/"
+    PUBLIC "${CMAKE_CURRENT_BINARY_DIR}/../include/v3x"
     PRIVATE "${antlr4-runtime_INCLUDE_DIRS}/"
     PRIVATE "${fmt_INCLUDE_DIRS}/"
     PRIVATE "${tree-gen_INCLUDE_DIRS}/"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,7 +125,8 @@ set(ANTLR_OUTPUTS
 antlr_target(
     "${CMAKE_CURRENT_SOURCE_DIR}/../scripts/generate_antlr_parser.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/v3x"  # Input dir (grammar files)
-    "${CMAKE_CURRENT_BINARY_DIR}/v3x"  # Output dir (lexer and parser cpp files)
+    "${CMAKE_CURRENT_BINARY_DIR}/v3x"  # Sources output dir (lexer and parser cpp files)
+    "${CMAKE_CURRENT_BINARY_DIR}/../include/v3x"  # Include output dir (lexer and parser h files)
     "${ANTLR_OUTPUTS}"  # List of generated files
 )
 list(APPEND CQASM_V3X_SOURCES ${ANTLR_OUTPUTS})
@@ -315,9 +316,10 @@ install(
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 )
-get_target_property(INCLUDE_DIRS cqasm-lib-obj INTERFACE_INCLUDE_DIRECTORIES)
 install(
-    DIRECTORY ${INCLUDE_DIRS}
+    DIRECTORY
+        "${CMAKE_CURRENT_SOURCE_DIR}/../include/"
+        "${CMAKE_CURRENT_BINARY_DIR}/../include/v3x"
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-    PATTERN "*.hpp" PATTERN "*.inc"
+    FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h" PATTERN "*.inc"
 )


### PR DESCRIPTION
Address [this code review requested change](https://github.com/conan-io/conan-center-index/pull/17719#pullrequestreview-2009514193) for libqasm Conan package.

Fix CMake install:
- We were previously creating output folders in wrong places (e.g., `include` and `src` folders).

Move ANTLR's header files to `include/v3x`:
- `generate_antlr_parser.py` writes now output include files in a given `include` folder.

Remove unused type aliases from `cqasm-types.hpp`.

Update `version.hpp`, `CHANGELOG.md`, and `test_cqasm.js` to version 0.6.4.