### PR TITLE
Fix building of tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All the `tests`, except for `linux-x64` profiles, enable Address Sanitizer.
 Profiles are a shorthand for command line options. The command above could be written, similarly,  as: 
 
 ```
-conan build . -s:a compiler.cppstd=20 -s:a libqasm/*:build_type=Debug -o libqasm/*:build_tests=True -o libqasm/*:asan_enabled=True -b missing
+conan build . -s:a compiler.cppstd=20 -s:a libqasm/*:build_type=Debug -o libqasm/*:asan_enabled=True -c tools.build:skip_test=False -b missing
 ```
 
 This is the list of options that could be specified either in a profile or in the command line:
@@ -90,7 +90,7 @@ This is the list of options that could be specified either in a profile or in th
 - `libqasm/*:build_type={Debug,Release}`: builds in debug or release mode.
 - `libqasm/*:shared={True,False}`: builds a shared object library instead of a static library, if applicable.
 
-Tests are enabled by default. To disable them, use `-c tools.build:skip_test=True`.
+Tests are disabled by default. To enable them, use `-c tools.build:skip_test=False`.
 
 ## Install
 

--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -7,8 +7,5 @@ libqasm/*:build_type=Debug
 [options]
 libqasm/*:asan_enabled=False
 
-[conf]
-tools.build:skip_test=True
-
 [replace_requires]
 nodejs/*: nodejs/16.20.2

--- a/conan/profiles/release
+++ b/conan/profiles/release
@@ -7,8 +7,5 @@ libqasm/*:build_type=Release
 [options]
 libqasm/*:asan_enabled=False
 
-[conf]
-tools.build:skip_test=True
-
 [replace_requires]
 nodejs/*: nodejs/16.20.2

--- a/conan/profiles/tests-debug
+++ b/conan/profiles/tests-debug
@@ -6,3 +6,6 @@ libqasm/*:build_type=Debug
 
 [options]
 libqasm/*:asan_enabled=True
+
+[conf]
+tools.build:skip_test=False

--- a/conan/profiles/tests-release
+++ b/conan/profiles/tests-release
@@ -6,3 +6,6 @@ libqasm/*:build_type=Release
 
 [options]
 libqasm/*:asan_enabled=True
+
+[conf]
+tools.build:skip_test=False

--- a/setup.py
+++ b/setup.py
@@ -107,8 +107,8 @@ class build_ext(_build_ext):
                 ['-b']['missing']
                 ['-tf']['']
             )
-            if not build_tests:
-                cmd = cmd['-c']['tools.build:skip_test=True']
+            if build_tests:
+                cmd = cmd['-c']['tools.build:skip_test=False']
             if platform.system() == "Darwin":
                 cmd = cmd['-c']['tools.build:defines=["_LIBCPP_DISABLE_AVAILABILITY"]']
             cmd & FG

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ class build_ext(_build_ext):
                 ['-b']['missing']
                 ['-tf']['']
             )
-            if build_tests:
+            if build_tests == "True":
                 cmd = cmd['-c']['tools.build:skip_test=False']
             if platform.system() == "Darwin":
                 cmd = cmd['-c']['tools.build:defines=["_LIBCPP_DISABLE_AVAILABILITY"]']


### PR DESCRIPTION
Tests should be built when we specify the configuration option `tools.build:skip_test=False`.

This is done correctly (has already been fixed) for QX simulator, but is broken at the moment for libqasm.