### PR TITLE
[CQT-135] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,13 +95,12 @@ if __name__ == "__main__":
 
 ## Documentation
 
-The [libQASM documentation](https://QuTech-Delft.github.io/OpenSquirrel/) is hosted through GitHub Pages.
+The [libQASM documentation](https://QuTech-Delft.github.io/libqasm/) is hosted through GitHub Pages.
 
 ## License
 
-libQASM is licensed under the Apache License, Version 2.0. See
-[LICENSE](https://github.com/QuTech-Delft/OpenSquirrel/blob/master/LICENSE.md) for the full
-license text.
+libQASM is licensed under the Apache License, Version 2.0.
+See [LICENSE](https://github.com/QuTech-Delft/libqasm/blob/master/LICENSE.md) for the full license text.
 
 ## Authors
 

--- a/doc/mkdocs.yml
+++ b/doc/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - User Guide:
     - User Guide: user-guide/user-guide.md
     - C++: user-guide/cpp.md
+    - Docker: user-guide/docker.md
     - Emscripten: user-guide/emscripten.md
     - Python: user-guide/python.md
   - Developer Guide:

--- a/doc/src/api/cpp.md
+++ b/doc/src/api/cpp.md
@@ -1,4 +1,4 @@
-`libqasm` C++ API is defined in `include/v3x/cqasm-py.hpp`.
+libQASM C++ API is defined in `include/v3x/cqasm-py.hpp`.
 
 The only exported class is `V3xAnalyzer`.
 This is actually a C++ class that works as a binding for accessing C++ code from Python.

--- a/doc/src/api/emscripten.md
+++ b/doc/src/api/emscripten.md
@@ -1,6 +1,6 @@
-`libqasm` is also deployed as an Emscripten binary with a Typescript frontend.
+libQASM is also deployed as an Emscripten binary with a Typescript frontend.
 
-`libqasm` Typescript API is defined in `emscripten/emscripten_wrapper.hpp`.
+libQASM Typescript API is defined in `emscripten/emscripten_wrapper.hpp`.
 
 The only exported class is `EmscriptenWrapper`.
 This is actually a C++ class that works as a binding for accessing C++ code from Typescript.

--- a/doc/src/api/python.md
+++ b/doc/src/api/python.md
@@ -1,4 +1,4 @@
-`libqasm` Python API is defined in `python/module/cqasm/v3x/__init__.py`.
+libQASM Python API is defined in `python/module/cqasm/v3x/__init__.py`.
 
 The only exported class is `Analyzer`.
 This is actually a Python class that works as a binding for accessing C++ code from Python.

--- a/doc/src/dev-guide/dev-guide.md
+++ b/doc/src/dev-guide/dev-guide.md
@@ -28,6 +28,7 @@ Build outputs may go into:
 - `git`
 - `Python` 3.x plus `pip`, with the following package:
     - `conan` >= 2.0
+- `SWIG`
 
 ### ARM builds
 
@@ -48,7 +49,7 @@ For the time being, we install Java manually for this platform.
 
 ## Build
 
-This version of `libqasm` can only be compiled via the Conan package manager.
+This version of libQASM can only be compiled via the Conan package manager.
 You will need to create a default profile before using it for the first time.
 
 The installation of dependencies, as well as the compilation, can be done in one go.
@@ -63,14 +64,14 @@ conan build . -pr:a=conan/profiles/tests-debug -b missing
 !!! note
 
     - the `conan profile` command only has to be run only once, and not before every build.
-    - the `conan build` command is building `libqasm` in Debug mode with tests using the `tests-debug` profile.
+    - the `conan build` command is building libQASM in Debug mode with tests using the `tests-debug` profile.
     - the `-b missing` parameter asks `conan` to build packages from sources
       in case it cannot find the binary packages for the current configuration (platform, OS, compiler, build type...).
 
 ### Profiles
 
 A group of predefined profiles is provided under the `conan/profiles` folder.  
-They follow the `[tests|docs](-build_type)(-compiler)(-os)(-arch)[-shared]` naming convention:
+They follow the `[tests-|docs-](build_type)(-compiler)(-os)(-arch)[-shared]` naming convention:
 
 - `tests`: if tests are being built.
 - `docs`: if docs are being built.
@@ -113,7 +114,7 @@ python3 mkdocs serve
 
 ## Docker
 
-This tests the library in a container with the bare minimum requirements for `libqasm`.
+This tests the library in a container with the bare minimum requirements for libQASM.
 
 ```shell
 docker build .

--- a/doc/src/dev-guide/emscripten.md
+++ b/doc/src/dev-guide/emscripten.md
@@ -10,8 +10,9 @@ The output of this build lives in `build/Release/emscripten`:
 - `cqasm_emscripten.js`.
 - `cqasm_emscripten.wasm`.
 
-Note that `cqasm_emscripten.js` is an ES6 module.
-Its extension has to be renamed to `.mjs` before using it from Typescript code.
+!!! note
+    `cqasm_emscripten.js` is an ES6 module.
+    Its extension has to be renamed to `.mjs` before using it from Typescript code.
 
 You can test the Emscripten binaries:
 

--- a/doc/src/user-guide/cpp.md
+++ b/doc/src/user-guide/cpp.md
@@ -1,4 +1,4 @@
-`libqasm` can be requested as a Conan package from a `conanfile.py`.
+libQASM can be requested as a Conan package from a `conanfile.py`.
 
 ```
 def build_requirements(self):
@@ -13,9 +13,8 @@ And then linked against from a `CMakeLists.txt`:
 target_link_libraries(<your target> PUBLIC libqasm::libqasm)
 ```
 
-Note that the following dependency is required for `libqasm` to build:
-
-* `Java JRE` >= 11
+!!! note
+    You will need to have `Java JRE` >= 11 installed in case Conan needs to build libQASM.
 
 **Example**:
 

--- a/doc/src/user-guide/docker.md
+++ b/doc/src/user-guide/docker.md
@@ -1,0 +1,13 @@
+libQASM can be tested in a container with the bare minimum requirements.
+
+```shell
+docker build .
+```
+
+!!! note
+    The above might fail on Windows due to the `autocrlf` transformation that git does.
+    If you are having trouble with this just create new clone of this repository using:
+
+    ```
+    git clone --config core.autocrlf=input git@github.com:QuTech-Delft/libqasm.git
+    ```

--- a/doc/src/user-guide/emscripten.md
+++ b/doc/src/user-guide/emscripten.md
@@ -1,4 +1,4 @@
-`libqasm` can be used from a web environment via a Typescript frontend.
+libQASM can be used from a web environment via a Typescript frontend.
 
 Emscripten API only allows to input a cQASM program via a string
 and always returns a JSON string output. 

--- a/doc/src/user-guide/python.md
+++ b/doc/src/user-guide/python.md
@@ -1,4 +1,4 @@
-`libqasm` can be imported as a Python package. 
+libQASM can be imported as a Python package. 
 
 **Example**:
 

--- a/doc/src/user-guide/user-guide.md
+++ b/doc/src/user-guide/user-guide.md
@@ -1,5 +1,6 @@
-`libqasm` can be used from:
+libQASM can be used from:
 
 - C++ projects (as a [Conan package](https://conan.io/center/recipes/libqasm)).
 - Python projects (as a [Python package](https://pypi.org/project/libqasm/)).
 - Emscripten projects (via a Typescript frontend).
+- Docker.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,12 +74,8 @@ if(NOT range-v3_FOUND)
     add_library(range-v3::range-v3 ALIAS range-v3)
 endif()
 
-# tree-gen executable
-find_package(tree-gen REQUIRED)
-find_program(TREE_GEN_EXECUTABLE tree-gen REQUIRED)
-message(STATUS "TREE_GEN_EXECUTABLE: ${TREE_GEN_EXECUTABLE}")
-
 # tree-gen library
+find_package(tree-gen REQUIRED)
 if(NOT tree-gen_FOUND OR LIBQASM_BUILD_EMSCRIPTEN)
     message(STATUS "Fetching tree-gen")
     FetchContent_Declare(tree-gen
@@ -89,6 +85,10 @@ if(NOT tree-gen_FOUND OR LIBQASM_BUILD_EMSCRIPTEN)
     )
     FetchContent_MakeAvailable(tree-gen)
 endif()
+
+# tree-gen executable
+find_program(TREE_GEN_EXECUTABLE tree-gen REQUIRED)
+message(STATUS "TREE_GEN_EXECUTABLE: ${TREE_GEN_EXECUTABLE}")
 
 #-------------------------------------------------------------------------------
 # cQASM common code generation and inclusion


### PR DESCRIPTION
This task is part of a greater task of updating the documentation for the whole of the cQASM tooling.

README files have to be updated. Some information needs to be added, modified, deleted, or moved to other documentation hosting systems (e.g., GitHub pages, ReadTheDocs, or Confluence).

The README files across the cQASM tooling should look consistent.