### PR TITLE
[CQT-27] Fix MacOS/x64 (with Python >= 3.11) wheels

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -9,247 +9,61 @@ on:
       - "release**"
 
 jobs:
-  macos-x64:
-    name: PyPI wheels for macOS/x64
-    runs-on: macos-13  # x64
+  cibw-wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+        # macos-13 is an x64 runner, macos-14 is an arm64 runner
+        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip conan setuptools wheel
-          brew install swig
-      - name: Build wheel
-        run: python setup.py bdist_wheel
-      - name: Wheel path
-        id: wheel
-        working-directory: pybuild/dist/
-        run: |
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_OUTPUT
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_ENV
+      - name: Install cibuildwheel
+        run: python -m pip install cibuildwheel==2.18.1
+      - name: Build wheels
+        run: python -m cibuildwheel --output-dir wheelhouse
       - uses: actions/upload-artifact@v4
         with:
-          name: pypi-macos-x64-py${{ matrix.python }}
-          path: pybuild/dist/${{ env.WHEEL_NAME }}
-      - uses: actions/upload-release-asset@v1
-        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: pybuild/dist/${{ env.WHEEL_NAME }}
-          asset_name: ${{ env.WHEEL_NAME }}
-          asset_content_type: application/zip
+          name: cibw-wheels-${{ matrix.os }}
+          path: ./wheelhouse/*.whl
 
-  macos-arm64:
-    name: PyPI wheels for macOS/arm64
-    runs-on: macos-14  # arm64
-    strategy:
-      matrix:
-        python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
+  cibw-wheels-linux-arm64:
+    name: Build wheels on linux-arm64
+    runs-on: [self-hosted, ARM64, Linux]
+    container:
+      image: python:3.12-slim
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
+      - name: Install docker
         run: |
-          python -m pip install --upgrade pip conan setuptools wheel
-          brew install swig
-      - name: Build wheel
-        run: python setup.py bdist_wheel
-      - name: Wheel path
-        id: wheel
-        working-directory: pybuild/dist/
-        run: |
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_OUTPUT
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pypi-macos-arm64-py${{ matrix.python }}
-          path: pybuild/dist/${{ env.WHEEL_NAME }}
-      - uses: actions/upload-release-asset@v1
-        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: pybuild/dist/${{ env.WHEEL_NAME }}
-          asset_name: ${{ env.WHEEL_NAME }}
-          asset_content_type: application/zip
+          apt-get update
+          apt-get install -y ca-certificates curl
+          install -m 0755 -d /etc/apt/keyrings
+          curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+          chmod a+r /etc/apt/keyrings/docker.asc
 
-  manylinux-x64:
-    name: PyPI wheels for Manylinux (x64)
-    runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux${{ matrix.manylinux }}_x86_64:latest
-    env:
-      SWIG_VERSION: ${{ matrix.swig_version }}
-    strategy:
-      matrix:
-        manylinux:
-          - "_2_28"
-        cpython_version:
-          - "cp38-cp38"
-          - "cp39-cp39"
-          - "cp310-cp310"
-          - "cp311-cp311"
-          - "cp312-cp312"
-        include:
-          - manylinux: _2_28
-            swig_version: 'swig-3.0.12-19.module_el8.3.0+6167+838326ab'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install dependencies
+          echo \
+            "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
+            $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+            tee /etc/apt/sources.list.d/docker.list > /dev/null
+          apt-get update
+          apt-get install -y docker-ce-cli
+      - name: Install cibuildwheel and build wheels
         run: |
-          dnf install -y $SWIG_VERSION
-          export PATH="/opt/python/${{ matrix.cpython_version }}/bin:$PATH"
-          python -m pip install --upgrade pip conan wheel auditwheel
-      - name: Build wheel
-        run: |
-          export PATH="/opt/python/${{ matrix.cpython_version }}/bin:$PATH"
-          conan remove -c "*/*"
-          /opt/python/${{ matrix.cpython_version }}/bin/python setup.py bdist_wheel
-          /opt/python/${{ matrix.cpython_version }}/bin/python -m auditwheel repair pybuild/dist/*.whl
-      - name: Wheel path
-        id: wheel
-        working-directory: wheelhouse
-        run: |
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_OUTPUT
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_ENV
+          pip install cibuildwheel==2.18.1
+          cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_BEFORE_ALL_LINUX: yum install -y java-11-openjdk
       - uses: actions/upload-artifact@v4
         with:
-          name: pypi-linux-x64-${{ matrix.cpython_version }}
-          path: wheelhouse/${{ env.WHEEL_NAME }}
-      - uses: actions/upload-release-asset@v1
-        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: wheelhouse/${{ env.WHEEL_NAME }}
-          asset_name: ${{ env.WHEEL_NAME }}
-          asset_content_type: application/zip
-
-  manylinux-arm64:
-    name: PyPI wheels for Manylinux (arm64)
-    runs-on:
-      - "self-hosted"
-      - "ARM64"
-      - "Linux"
-    container: quay.io/pypa/manylinux${{ matrix.manylinux }}_aarch64:latest
-    env:
-      JAVA_VERSION: ${{ matrix.java_version }}
-      SWIG_VERSION: ${{ matrix.swig_version }}
-    strategy:
-      matrix:
-        manylinux:
-          - "_2_28"
-        cpython_version:
-          - "cp38-cp38"
-          - "cp39-cp39"
-          - "cp310-cp310"
-          - "cp311-cp311"
-          - "cp312-cp312"
-        # We are having problems when zulu-opendjk Conan package on an armv8 architecture.
-        # zulu-openjdk provides the Java JRE required by the ANTLR generator.
-        # So, for the time being, we are installing Java manually for this platform
-        include:
-          - manylinux: _2_28
-            java_version: 'java-11-openjdk-11.0.21.0.9-2.el8'
-            swig_version: 'swig-3.0.12-19.module_el8.4.0+2254+838326ab'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install dependencies
-        run: |
-          dnf install -y $JAVA_VERSION $SWIG_VERSION
-          export PATH="/opt/python/${{ matrix.cpython_version }}/bin:$PATH"
-          python -m pip install --upgrade pip conan wheel auditwheel
-      - name: Build wheel
-        run: |
-          export PATH="/opt/python/${{ matrix.cpython_version }}/bin:$PATH"
-          conan remove -c "*/*"
-          python setup.py bdist_wheel
-          python -m auditwheel repair pybuild/dist/*.whl
-      - name: Wheel path
-        id: wheel
-        working-directory: wheelhouse
-        run: |
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_OUTPUT
-          echo "WHEEL_NAME=$(ls *.whl)" >> $GITHUB_ENV
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pypi-linux-arm64-${{ matrix.cpython_version }}
-          path: wheelhouse/${{ env.WHEEL_NAME }}
-      - uses: actions/upload-release-asset@v1
-        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: wheelhouse/${{ env.WHEEL_NAME }}
-          asset_name: ${{ env.WHEEL_NAME }}
-          asset_content_type: application/zip
-
-  windows-x64:
-    name: PyPI wheels for Windows
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python:
-          - "3.8"
-          - "3.9"
-          - "3.10"
-          - "3.11"
-          - "3.12"
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python }}
-      - name: Install dependencies
-        run: python -m pip install --upgrade pip conan setuptools wheel
-      - name: Build wheel
-        run: python setup.py bdist_wheel
-      - name: Wheel path
-        id: wheel
-        working-directory: pybuild/dist/
-        run: |
-          echo "WHEEL_NAME=$(Get-ChildItem -name *.whl)" >> $env:GITHUB_OUTPUT
-          echo "WHEEL_NAME=$(Get-ChildItem -name *.whl)" >> $env:GITHUB_ENV
-        shell: powershell
-      - uses: actions/upload-artifact@v4
-        with:
-          name: pypi-windows-py${{ matrix.python }}
-          path: pybuild/dist/${{ env.WHEEL_NAME }}
-      - uses: actions/upload-release-asset@v1
-        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: pybuild/dist/${{ env.WHEEL_NAME }}
-          asset_name: ${{ env.WHEEL_NAME }}
-          asset_content_type: application/zip
+          name: cibw-wheels-linux-arm64
+          path: ./wheelhouse/*.whl
 
   emscripten-wasm:
     name: WASM binaries for emscripten
@@ -292,13 +106,9 @@ jobs:
 
   publish:
     name: Publish
-    if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
     needs:
-      - macos-x64
-      - macos-arm64
-      - manylinux-x64
-      - manylinux-arm64
-      - windows-x64
+      - cibw-wheels
+      - cibw-wheels-linux-arm64
       - emscripten-wasm
     runs-on: ubuntu-latest
     steps:
@@ -307,7 +117,8 @@ jobs:
         id: download
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14
+        if: ${{ github.event_name == 'release' && github.event.action == 'created' }}
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
-          packages_dir: ${{ steps.download.outputs.download-path }}/pypi-*
+          packages_dir: ${{ steps.download.outputs.download-path }}/cibw-*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = [
+    "setuptools",
+    "swig"
+]
+build-backend = "setuptools.build_meta"
+
+[tool.cibuildwheel]
+before-all = "uname -a"
+build-verbosity = 3
+skip = [
+    "cp36-*", "cp37-*", "cp38-*",
+    "*i686*", "*ppc64le*", "*pypy*", "*s390x*", "*musllinux*",
+    "pp*",
+    "*-win32",
+]
+test-requires = "pytest"
+test-command = "pytest {project}/test"
+
+[tool.cibuildwheel.linux]
+manylinux-x86_64-image = "manylinux_2_28"
+manylinux-aarch64-image = "manylinux_2_28"

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@ from distutils.command.build import build as _build
 from setuptools.command.install import install as _install
 
 
-# TODO: I had to copy-paste get_version from version.py here
-#  because I couldn't get 'from version import get_version' work with pyproject.toml
 def get_version(verbose=False):
     """Extract version information from source code"""
     inc_dir = root_dir + os.sep + "include"  # C++ include directory

--- a/setup.py
+++ b/setup.py
@@ -12,19 +12,31 @@ from distutils.command.clean import clean as _clean
 from setuptools.command.build_ext import build_ext as _build_ext
 from distutils.command.build import build as _build
 from setuptools.command.install import install as _install
-from distutils.command.bdist import bdist as _bdist
-from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
-from distutils.command.sdist import sdist as _sdist
-from setuptools.command.egg_info import egg_info as _egg_info
 
-from version import get_version
+
+# TODO: I had to copy-paste get_version from version.py here
+#  because I couldn't get 'from version import get_version' work with pyproject.toml
+def get_version(verbose=False):
+    """Extract version information from source code"""
+    inc_dir = root_dir + os.sep + "include"  # C++ include directory
+    matcher = re.compile('static const char \*version\{ "(.*)" \}')
+    version = None
+    with open(os.path.join(inc_dir, "version.hpp"), "r") as f:
+        for ln in f:
+            m = matcher.match(ln)
+            if m:
+                version = m.group(1)
+                break
+    if verbose:
+        print("get_version: %s" % version)
+    return version
+
 
 root_dir = os.getcwd()  # root of the repository
 src_dir = root_dir + os.sep + 'src'  # C++ source directory
 pysrc_dir = root_dir + os.sep + 'python'  # Python source files
 target_dir = root_dir + os.sep + 'pybuild'  # python-specific build directory
 build_dir = target_dir + os.sep + 'build'  # directory for setuptools to dump various files into
-dist_dir = target_dir + os.sep + 'dist'  # wheel output directory
 cbuild_dir = target_dir + os.sep + 'cbuild'  # cmake build directory
 prefix_dir = target_dir + os.sep + 'prefix'  # cmake install prefix
 srcmod_dir = pysrc_dir + os.sep + 'module'  # libqasm Python module directory, source files only
@@ -134,31 +146,6 @@ class install(_install):
         _install.run(self)
 
 
-class bdist(_bdist):
-    def finalize_options(self):
-        _bdist.finalize_options(self)
-        self.dist_dir = os.path.relpath(dist_dir)
-
-
-class bdist_wheel(_bdist_wheel):
-    def run(self):
-        if platform.system() == "Darwin":
-            os.environ['MACOSX_DEPLOYMENT_TARGET'] = '10.10'
-        _bdist_wheel.run(self)
-
-
-class sdist(_sdist):
-    def finalize_options(self):
-        _sdist.finalize_options(self)
-        self.dist_dir = os.path.relpath(dist_dir)
-
-
-class egg_info(_egg_info):
-    def initialize_options(self):
-        _egg_info.initialize_options(self)
-        self.egg_base = os.path.relpath(module_dir)
-
-
 setup(
     name='libqasm',
     version=get_version(),
@@ -173,6 +160,11 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Scientific/Engineering'
     ],
     packages=['libqasm', 'cqasm', 'cqasm.v3x'],
@@ -182,14 +174,10 @@ setup(
     # This is here just to have the rest of setuptools understand that this is a Python module with an extension in it.
     ext_modules=[Extension('libqasm._libqasm', [])],
     cmdclass={
-        'bdist': bdist,
-        'bdist_wheel': bdist_wheel,
         'build_ext': build_ext,
         'build': build,
         'install': install,
         'clean': clean,
-        'egg_info': egg_info,
-        'sdist': sdist,
     },
     setup_requires=[
         'conan',

--- a/setup.py
+++ b/setup.py
@@ -160,7 +160,6 @@ setup(
         'Operating System :: MacOS',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',


### PR DESCRIPTION
Issue:
We are generating universal instead of x86_64 binaries.
According to this [thread](https://github.com/pypa/wheel/issues/573), it's highly recommended to move to cibuildwheel as wheel creator.

Changes:
- Use cibuildwheel for generating the wheels.
- Remove support for Python 3.8 (the combo cibuildwheel/macos14/CPython 3.8 didn't work).
- Add pyproject.toml.
- Update setup.py: remove bdist, bdist_wheel, sdist, and egg_info.