### PR TITLE
Update `develop` with last minute changes made to `master`

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -1,0 +1,34 @@
+name: Linters
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  cpp-linters:
+    name: "C++ linters"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run C++ linters
+        uses: cpp-linter/cpp-linter-action@v2
+        id: linter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          extensions: 'cpp,hpp'
+          files-changed-only: 'true'
+          format-review: 'true'
+          style: 'file'  # use .clang-format config file
+          tidy-checks: '-*'  # disable clang-tidy checks
+          version: 18
+      - name: Fail fast
+        if: steps.linter.outputs.clang-format-checks-failed > 0
+        run: |
+          echo "::notice::Try executing 'python3 ./scripts/run_cpp_linters.py .' to fix linter issues."
+          exit 1

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -22,8 +22,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           extensions: 'cpp,hpp'
-          files-changed-only: 'true'
-          format-review: 'true'
           style: 'file'  # use .clang-format config file
           tidy-checks: '-*'  # disable clang-tidy checks
           version: 18

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,33 +8,8 @@ on:
   pull_request:
 
 jobs:
-  cpp-linters:
-    name: "C++ linters"
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Run C++ linters
-        uses: cpp-linter/cpp-linter-action@v2
-        id: linter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          extensions: 'cpp,hpp'
-          files-changed-only: 'false'
-          format-review: 'true'
-          style: 'file'  # use .clang-format config file
-          tidy-checks: '-*'  # disable clang-tidy checks
-          version: 18
-      - name: Fail fast
-        if: steps.linter.outputs.clang-format-checks-failed > 0
-        run: |
-          echo "::notice::Try executing 'python3 ./scripts/run_cpp_linters.py .' to fix linter issues."
-          exit 1
-
   cpp-linux-x64:
     name: "C++ tests (gcc-clang/Linux/x64)"
-    needs: cpp-linters
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -56,10 +31,10 @@ jobs:
 
   cpp-linux-arm64:
     name: "C++ tests (gcc/Linux/ARM64)"
-    needs: cpp-linters
     runs-on: [self-hosted, ARM64, Linux]
     container: python:3.11
-    # Run only when merging to develop (until we have a GitHub-hosted runner for Linux/ARM64)
+    # Run only when merging to develop
+    # (until we have a GitHub-hosted runner for Linux/ARM64)
     if: github.ref == 'refs/heads/develop'
     strategy:
       fail-fast: false
@@ -89,7 +64,6 @@ jobs:
 
   cpp-macos-x64:
     name: "C++ tests (clang/MacOS/x64)"
-    needs: cpp-linters
     runs-on: macos-13  # x64
     strategy:
       fail-fast: false
@@ -108,7 +82,6 @@ jobs:
 
   cpp-macos-arm64:
     name: "C++ tests (clang/macos/ARM64)"
-    needs: cpp-linters
     runs-on: macos-14  # arm64
     strategy:
       fail-fast: false
@@ -127,7 +100,6 @@ jobs:
 
   cpp-windows-x64:
     name: "C++ tests (msvc/Windows/x64)"
-    needs: cpp-linters
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -147,7 +119,6 @@ jobs:
 
   cpp-shared:
     name: "C++ tests (shared)"
-    needs: cpp-linters
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -166,7 +137,6 @@ jobs:
 
   ts-emscripten-wasm:
     name: "TS tests (clang/emscripten/wasm)"
-    needs: cpp-linters
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -212,7 +182,6 @@ jobs:
 
   python-linux-x64:
     name: "Python tests (Linux/x64)"
-    needs: cpp-linters
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -231,7 +200,6 @@ jobs:
 
   python-macos-x64:
     name: "Python tests (macOS/x64)"
-    needs: cpp-linters
     runs-on: macos-13
     steps:
       - name: Checkout
@@ -250,7 +218,6 @@ jobs:
 
   python-macos-arm64:
     name: "Python tests (macOS/arm64)"
-    needs: cpp-linters
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -269,7 +236,6 @@ jobs:
 
   python-windows-x64:
     name: "Python tests (Windows/x64)"
-    needs: cpp-linters
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -284,7 +250,6 @@ jobs:
 
   docker:
     name: Docker
-    needs: cpp-linters
     runs-on: ubuntu-latest
     steps:
       - name: Set up QEMU


### PR DESCRIPTION
Due to an issue with the `cpp-linter-action`, we had to do some last minute changes in `master`:
- Move cpp-linters job to a Linters workflow.
- Change cpp-linters job to run only for:
  - merges to develop, and
  - pull requests to develop.
- Remove cpp-linters job from Test workflow.

This PR is updating `develop` with those last minute changes from `master`.

---

It also adds an extra change:
- Remove `files-changed-only` and `format-review` linter options (thus using their `false` default value).

Explanation: if we expect some of our PRs to have a large diff, then we should disable any features that rely on having diff information:
- `lines-changed-only`,
- `files-changed-only`,
- `format-review`, and
- `tidy-review`.

For a more detailed explanation: https://github.com/cpp-linter/cpp-linter-action/issues/274#issuecomment-2419903580