### PR TITLE
Fix 'Upload and tag as git tag with every release creation on master branch' on Publish GitHub pages job.

### DIFF
--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -46,5 +46,5 @@ jobs:
       - name: Upload and tag as git tag with every release creation on master branch
         if: github.event_name == 'release' && github.event.action == 'created'
         run: |
-          mike deploy --push ${{ github.ref }}
+          mike deploy --push ${{ github.ref_name }}
           mike set-default --push latest


### PR DESCRIPTION
Last release creation showed an error when publishing the GitHub pages.
It turns out a variable name was wrong in the Publish GitHub pages job.
Change `github.ref` to `github.ref_name`.