### PR TITLE
Release 0.6.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## [ 0.6.9 ] - [ 2024-11-13 ]
+
+### Added
+- `SWAP` unitary instruction.
+- `init`, `barrier`, and `wait` non-unitary instructions.
+
+### Changed
+
+### Removed
+- `reset` without qubit operands form.
+
+
 ## [ 0.6.8 ] - [ 2024-10-16 ]
 
 ### Added
@@ -32,6 +44,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 - Python 3.8 packages generation.
+
 
 ## [ 0.6.6 ] - [ 2024-05-14 ]
 

--- a/docs/dev-guide/cpp.md
+++ b/docs/dev-guide/cpp.md
@@ -6,7 +6,7 @@ The following line will also build and cache the `libqasm` Conan package.
 
 ```shell
 conan profile detect
-conan create --version 0.6.8 . -pr:a=tests-debug -b missing
+conan create --version 0.6.9 . -pr:a=tests-debug -b missing
 ```
 
 You can test the C++ binaries:

--- a/docs/user-guide/cpp.md
+++ b/docs/user-guide/cpp.md
@@ -2,9 +2,9 @@ libQASM can be requested as a Conan package from a `conanfile.py`.
 
 ```
 def build_requirements(self):
-    self.tool_requires("libqasm/0.6.8")
+    self.tool_requires("libqasm/0.6.9")
 def requirements(self):
-    self.requires("libqasm/0.6.8")
+    self.requires("libqasm/0.6.9")
 ```
 
 And then linked against from a `CMakeLists.txt`:

--- a/emscripten/test_libqasm.ts
+++ b/emscripten/test_libqasm.ts
@@ -8,7 +8,7 @@ wrapper().then(function(result: any) {
 
     try {
         let output = cqasm.get_version()
-        let expected_output = "0.6.8"
+        let expected_output = "0.6.9"
         console.log("\nThe version of libqasm compiled with emscripten is:", output);
         if (output !== expected_output) {
             console.log("\tExpected output:", expected_output)

--- a/include/libqasm/versioning.hpp
+++ b/include/libqasm/versioning.hpp
@@ -2,7 +2,7 @@
 
 namespace cqasm {
 
-static const char* version{ "0.6.8" };
+static const char* version{ "0.6.9" };
 static const char* release_year{ "2024" };
 
 [[nodiscard]] [[maybe_unused]] static const char* get_version() {


### PR DESCRIPTION
### Added
- `SWAP` unitary instruction.
- `init`, `barrier`, and `wait` non-unitary instructions.

### Changed

### Removed
- `reset` without qubit operands form.