### PR TITLE
Minor fixes on the build system

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -190,10 +190,6 @@ jobs:
         run: |
           sudo apt-get install -y swig
         shell: bash
-      - name: Export LIBQASM_BUILD_TYPE
-        run: |
-          echo "LIBQASM_BUILD_TYPE=Debug" >> $GITHUB_ENV
-        shell: bash
       - uses: ./.github/actions/python-tests
         with:
           shell: bash
@@ -207,10 +203,6 @@ jobs:
       - name: Install SWIG
         run: |
           brew install swig
-        shell: bash
-      - name: Export LIBQASM_BUILD_TYPE
-        run: |
-          echo "LIBQASM_BUILD_TYPE=Debug" >> $GITHUB_ENV
         shell: bash
       - uses: ./.github/actions/python-tests
         with:
@@ -226,10 +218,6 @@ jobs:
         run: |
           brew install swig
         shell: bash
-      - name: Export LIBQASM_BUILD_TYPE
-        run: |
-          echo "LIBQASM_BUILD_TYPE=Debug" >> $GITHUB_ENV
-        shell: bash
       - uses: ./.github/actions/python-tests
         with:
           shell: bash
@@ -240,10 +228,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Export LIBQASM_BUILD_TYPE
-        run: |
-          echo "LIBQASM_BUILD_TYPE=Release" >> $env:GITHUB_ENV
-        shell: powershell
       - uses: ./.github/actions/python-tests
         with:
           shell: bash
@@ -266,15 +250,16 @@ jobs:
     # see https://github.community/t/status-check-for-a-matrix-jobs/127354/7
     name: Report status
     needs:
-      - cpp-shared
       - cpp-linux-x64
-      - cpp-macos-x64
-      - cpp-windows-x64
       - cpp-linux-arm64
+      - cpp-macos-x64
       - cpp-macos-arm64
+      - cpp-windows-x64
+      - cpp-shared
       - ts-emscripten-wasm
       - python-linux-x64
       - python-macos-x64
+      - python-macos-arm64
       - python-windows-x64
       - docker
     if: ${{ always() }}

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,10 @@ from setuptools.command.install import install as _install
 
 def get_version(verbose=False):
     """Extract version information from source code"""
-    inc_dir = os.path.join(root_dir, "include", "libqasm")  # C++ include directory
-    matcher = re.compile('static const char\* version\{ "(.*)" \}')
+    inc_dir = os.path.join(root_dir, 'include', 'libqasm')  # C++ include directory
+    matcher = re.compile('static const char\* version\{ "(.*)" }')
     version = None
-    with open(os.path.join(inc_dir, "versioning.hpp"), "r") as f:
+    with open(os.path.join(inc_dir, 'versioning.hpp'), 'r') as f:
         for ln in f:
             m = matcher.match(ln)
             if m:
@@ -91,9 +91,8 @@ class build_ext(_build_ext):
 
         # Configure and build using Conan
         with local.cwd(root_dir):
-            # Build type can be set using an environment variable
-            build_type = os.environ.get('LIBQASM_BUILD_TYPE', 'Release')
-            build_tests = os.environ.get("LIBQASM_BUILD_TESTS", "False")
+            build_type = os.environ.get('CMAKE_BUILD_TYPE', 'Release')
+            build_tests = os.environ.get('LIBQASM_BUILD_TESTS', 'False')
 
             cmd = local['conan']['profile']['detect']['--force']
             cmd & FG
@@ -117,9 +116,9 @@ class build_ext(_build_ext):
                 ['-b']['missing']
                 ['-tf']['']
             )
-            if build_tests == "True":
+            if build_tests == 'True':
                 cmd = cmd['-c']['tools.build:skip_test=False']
-            if platform.system() == "Darwin":
+            if platform.system() == 'Darwin':
                 cmd = cmd['-c']['tools.build:defines=["_LIBCPP_DISABLE_AVAILABILITY"]']
             cmd & FG
 


### PR DESCRIPTION
setup.py:
- Change some double quotes to single quotes.
- Use CMAKE_BUILD_TYPE instead of LIBQASM_BUILD_TYPE.

test.yaml:
- Remove export of LIBQASM_BUILD_TYPE.
- Reorder list of needed jobs for the 'complete' job.
- Add python-macos-arm64 to the list of needed jobs for the 'complete' job.