### PR TITLE
Creating release 1.0.0

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -25,18 +25,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        # The Linux/ARM64 runner seems to be missing Java
-      - name: Install Java and add it to the path
-        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y default-jre
-          echo "/usr/bin" >> $GITHUB_PATH
-          java --version
       - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel==2.18.1
+        run: |
+          python -m pip install cibuildwheel==2.18.1
       - name: Build wheels
-        run: python -m cibuildwheel --output-dir wheelhouse
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
+        env:
+          CIBW_BEFORE_ALL_LINUX: sudo yum install -y java-11-openjdk
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -33,7 +33,7 @@ jobs:
           python -m cibuildwheel --output-dir wheelhouse
         if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         env:
-          CIBW_BEFORE_ALL_LINUX: sudo yum install -y java-11-openjdk
+          CIBW_BEFORE_ALL_LINUX: yum install -y java-11-openjdk
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -24,6 +24,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        # The Linux/ARM64 runner seems to be missing Java
+      - name: Install dependencies
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: |
+          apt-get update
+          apt-get install -y default-jre
       - uses: actions/setup-python@v5
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.18.1

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -24,13 +24,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         # The Linux/ARM64 runner seems to be missing Java
       - name: Install dependencies
-        if: matrix.os == 'ubuntu-24.04-arm'
+        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         run: |
           apt-get update
           apt-get install -y default-jre
-      - uses: actions/setup-python@v5
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.18.1
       - name: Build wheels

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -29,8 +29,8 @@ jobs:
       - name: Install dependencies
         if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         run: |
-          apt-get update
-          apt-get install -y default-jre
+          sudo apt-get update
+          sudo apt-get install -y default-jre
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.18.1
       - name: Build wheels

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -26,11 +26,13 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         # The Linux/ARM64 runner seems to be missing Java
-      - name: Install dependencies
+      - name: Install Java and add it to the path
         if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         run: |
           sudo apt-get update
           sudo apt-get install -y default-jre
+          echo "/usr/bin" >> $GITHUB_PATH
+          java --version
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel==2.18.1
       - name: Build wheels

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -195,6 +195,20 @@ jobs:
         with:
           shell: bash
 
+  python-linux-arm64:
+    name: "Python tests (Linux/arm64)"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install SWIG
+        run: |
+          sudo apt-get install -y swig
+        shell: bash
+      - uses: ./.github/actions/python-tests
+        with:
+          shell: bash
+
   python-macos-x64:
     name: "Python tests (macOS/x64)"
     runs-on: macos-13
@@ -259,6 +273,7 @@ jobs:
       - cpp-shared
       - ts-emscripten-wasm
       - python-linux-x64
+      - python-linux-arm64
       - python-macos-x64
       - python-macos-arm64
       - python-windows-x64

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
-## [ 1.0.0 ] - [ xxxx-yy-zz ]
+## [ 1.0.0 ] - [ 2025-01-30 ]
 
 ### Added
 - `.clang-tidy`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - `.clang-tidy`.
+- Python Linux/ARM64 GitHub Actions job.
 
 ### Changed
 - Error when redeclaring a variable.
@@ -75,7 +76,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Python module name from `libQasm` to `libqasm`.
 
 ## Fixed
-- Python MacOS/arm64 packages.
+- Python MacOS/ARM64 packages.
 - `scripts/generate_antlr_parser.py`.
 
 ### Removed

--- a/docs/dev-guide/cpp-dev-guide.md
+++ b/docs/dev-guide/cpp-dev-guide.md
@@ -7,7 +7,7 @@ The following line will also build and cache the `libqasm` Conan package.
 
 ```shell
 conan profile detect
-conan create --version 0.6.9 . -pr:a=tests-debug -b missing
+conan create --version 1.0.0 . -pr:a=tests-debug -b missing
 ```
 
 You can test the C++ binaries:

--- a/docs/user-guide/cpp-user-guide.md
+++ b/docs/user-guide/cpp-user-guide.md
@@ -2,9 +2,9 @@ libQASM can be requested as a Conan package from a `conanfile.py`:
 
 ```
 def build_requirements(self):
-    self.tool_requires("libqasm/0.6.9")
+    self.tool_requires("libqasm/1.0.0")
 def requirements(self):
-    self.requires("libqasm/0.6.9")
+    self.requires("libqasm/1.0.0")
 ```
 
 And then linked against from a `CMakeLists.txt`:

--- a/emscripten/test_libqasm.ts
+++ b/emscripten/test_libqasm.ts
@@ -8,7 +8,7 @@ wrapper().then(function(result: any) {
 
     try {
         let output = cqasm.get_version()
-        let expected_output = "0.6.9"
+        let expected_output = "1.0.0"
         console.log("\nThe version of libqasm compiled with emscripten is:", output);
         if (output !== expected_output) {
             console.log("\tExpected output:", expected_output)

--- a/include/libqasm/versioning.hpp
+++ b/include/libqasm/versioning.hpp
@@ -2,8 +2,8 @@
 
 namespace cqasm {
 
-static const char* version{ "0.6.9" };
-static const char* release_year{ "2024" };
+static const char* version{ "1.0.0" };
+static const char* release_year{ "2025" };
 
 [[nodiscard]] [[maybe_unused]] static const char* get_version() {
     return version;


### PR DESCRIPTION
### Added
- `.clang-tidy`.
- Python Linux/ARM64 GitHub Actions job.

### Changed
- Error when redeclaring a variable.
- Change Linux/ARM64 jobs to use GitHub-hosted runners.

### Fixed
- clang/Linux/x64 GitHub Actions jobs (which use Ubuntu 24.04.1 since 2025).