### PR TITLE
Do not hardcode CMAKE_CXX_STANDARD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
+## [ 1.0.1 ] - [ xxxx-yy-zz ]
+
+### Changed
+- Do not hardcode `CMAKE_CXX_STANDARD`.
+
+
 ## [ 1.0.0 ] - [ 2025-01-30 ]
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,9 @@ project(cqasm LANGUAGES C CXX)
 # There should be only one place for it and one version per project.
 if(NOT TARGET cqasm)
 
-set(CMAKE_CXX_STANDARD 20)
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 20)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mike==2.1.2
-mkdocs-material==9.5.29
-mkdocstrings==0.25.1
+mkdocs-material==9.6.5
+mkdocstrings==0.28.2
 pymdown-extensions==10.8.1


### PR DESCRIPTION
This is a suggestion coming from this [comment](https://github.com/conan-io/conan-center-index/pull/26499#pullrequestreview-2647168875).

> Following best CMake best practices from Professional CMake 19th edition:
> 
> > For a standalone project that will always be built as the top level project, hard-coding variables like
CMAKE_CXX_STANDARD and CMAKE_CXX_EXTENSIONS may be appropriate. But some projects may end up
being absorbed into a larger parent project (see Chapter 39, FetchContent), and that parent project
may want to enforce a higher language standard or make use of extensions that this project doesn’t
need.