### PR TITLE
Fix `build_type` compile flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Do not hardcode `CMAKE_CXX_STANDARD`.
 - Rename `ast` to `syntactic`.
 
+### Fixed
+- Setting of `build_type` in Conan profiles.
+
 
 ## [ 1.0.0 ] - [ 2025-01-30 ]
 

--- a/conan/profiles/debug
+++ b/conan/profiles/debug
@@ -2,7 +2,7 @@ include(default)
 
 [settings]
 compiler.cppstd=20
-libqasm/*:build_type=Debug
+build_type=Debug
 
 [options]
 libqasm/*:asan_enabled=False

--- a/conan/profiles/release
+++ b/conan/profiles/release
@@ -2,7 +2,7 @@ include(default)
 
 [settings]
 compiler.cppstd=20
-libqasm/*:build_type=Release
+build_type=Release
 
 [options]
 libqasm/*:asan_enabled=False

--- a/conan/profiles/tests-debug
+++ b/conan/profiles/tests-debug
@@ -2,7 +2,7 @@ include(default)
 
 [settings]
 compiler.cppstd=20
-libqasm/*:build_type=Debug
+build_type=Debug
 
 [options]
 libqasm/*:asan_enabled=True

--- a/conan/profiles/tests-release
+++ b/conan/profiles/tests-release
@@ -2,7 +2,7 @@ include(default)
 
 [settings]
 compiler.cppstd=20
-libqasm/*:build_type=Release
+build_type=Release
 
 [options]
 libqasm/*:asan_enabled=True


### PR DESCRIPTION
Set build_type compile option correctly.
This is the reason why Windows/debug builds were working in libQASM but not on QX simulator.