### PR TITLE
Fix `cibw-wheels` job in `master`

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -31,9 +31,8 @@ jobs:
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-        if: ${{ matrix.os == 'ubuntu-24.04-arm' }}
         env:
-          CIBW_BEFORE_ALL_LINUX: yum install -y java-11-openjdk
+          CIBW_BEFORE_ALL_LINUX: ${{ (matrix.os == 'ubuntu-24.04-arm') && 'yum install -y java-11-openjdk' || ':' }}
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}


### PR DESCRIPTION
Current 'Build wheels' step in cibw-wheels job is only being executed for Linux/ARM64, because of the 'if' clause.
Remove the 'if' clause.
Set CIBW_BEFORE_ALL_LINUX to the Java installation command for Linux/ARM64.
Set CIBW_BEFORE_ALL_LINUX to a no-op otherwise.
The name of this branch starts with 'release' in order to test the assets workflow.