### PR TITLE
Creating release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
-## [ 1.1.0 ] - [ xxxx-yy-zz ]
+## [ 1.1.0 ] - [ 2025-03-13 ]
 
 ### Added
 - Assembly declaration.

--- a/docs/dev-guide/cpp-dev-guide.md
+++ b/docs/dev-guide/cpp-dev-guide.md
@@ -7,7 +7,7 @@ The following line will also build and cache the `libqasm` Conan package.
 
 ```shell
 conan profile detect
-conan create --version 1.0.0 . -pr:a=tests-debug -b missing
+conan create --version 1.1.0 . -pr:a=tests-debug -b missing
 ```
 
 You can test the C++ binaries:

--- a/docs/user-guide/cpp-user-guide.md
+++ b/docs/user-guide/cpp-user-guide.md
@@ -2,9 +2,9 @@ libQASM can be requested as a Conan package from a `conanfile.py`:
 
 ```
 def build_requirements(self):
-    self.tool_requires("libqasm/1.0.0")
+    self.tool_requires("libqasm/1.1.0")
 def requirements(self):
-    self.requires("libqasm/1.0.0")
+    self.requires("libqasm/1.1.0")
 ```
 
 And then linked against from a `CMakeLists.txt`:

--- a/emscripten/test_libqasm.ts
+++ b/emscripten/test_libqasm.ts
@@ -8,7 +8,7 @@ wrapper().then(function(result: any) {
 
     try {
         let output = cqasm.get_version()
-        let expected_output = "1.0.0"
+        let expected_output = "1.1.0"
         console.log("\nThe version of libqasm compiled with emscripten is:", output);
         if (output !== expected_output) {
             console.log("\tExpected output:", expected_output)

--- a/include/libqasm/versioning.hpp
+++ b/include/libqasm/versioning.hpp
@@ -2,7 +2,7 @@
 
 namespace cqasm {
 
-static const char* version{ "1.0.0" };
+static const char* version{ "1.1.0" };
 static const char* release_year{ "2025" };
 
 [[nodiscard]] [[maybe_unused]] static const char* get_version() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libqasm",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/QuTech-Delft/libqasm.git"


### PR DESCRIPTION
### Added
- Assembly declaration.
- `Rn` unitary instruction.
- Publish WASM binaries to npm.

### Changed
- Update to `mkdocs-material/9.6.5` and `mkdocstrings/0.28.2` versions in `requirements.txt`.
- Do not hardcode `CMAKE_CXX_STANDARD`.
- Rename `ast` to `syntactic`.

### Fixed
- Setting of `build_type` in Conan profiles.
- `cibw-wheels` GitHub Actions job was building wheels only for Linux/ARM64.

## Removed
- Upload WASM binaries as release assets.