### PR TITLE
[CQT-358] Check that qubit operands of a gate instruction have the same number of indices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Removed** for now removed features.
 
 
+## [ 1.2.0 ] - [ xxxx-yy-zz ]
+
+### Added
+- Semantic analyzer check for same number of indices in each qubit operand.
+
+
 ## [ 1.1.0 ] - [ 2025-03-13 ]
 
 ### Added

--- a/res/v3x/tests/integration/sgmq/cnot_q_0_q_3_2/ast.golden.txt
+++ b/res/v3x/tests/integration/sgmq/cnot_q_0_q_3_2/ast.golden.txt
@@ -1,0 +1,109 @@
+SUCCESS
+Program(
+  version: <
+    Version( # input.cq:1:9..10
+      items: 3
+    )
+  >
+  block: <
+    GlobalBlock(
+      statements: [
+        Variable( # input.cq:3:10..11
+          name: <
+            Identifier(
+              name: q
+            )
+          >
+          typ: <
+            Type( # input.cq:3:1..9
+              name: <
+                Keyword(
+                  name: qubit
+                )
+              >
+              size: <
+                IntegerLiteral(
+                  value: 4
+                )
+              >
+            )
+          >
+          annotations: []
+        )
+        GateInstruction( # input.cq:5:1..5
+          gate: <
+            Gate( # input.cq:5:1..5
+              name: <
+                Identifier(
+                  name: CNOT
+                )
+              >
+              gate: -
+              parameters: <
+                ExpressionList(
+                  items: []
+                )
+              >
+              annotations: []
+            )
+          >
+          operands: <
+            ExpressionList(
+              items: [
+                Index( # input.cq:5:6..7
+                  expr: <
+                    Identifier(
+                      name: q
+                    )
+                  >
+                  indices: <
+                    IndexList(
+                      items: [
+                        IndexItem(
+                          index: <
+                            IntegerLiteral( # input.cq:5:8..9
+                              value: 0
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+                Index( # input.cq:5:12..13
+                  expr: <
+                    Identifier(
+                      name: q
+                    )
+                  >
+                  indices: <
+                    IndexList(
+                      items: [
+                        IndexItem(
+                          index: <
+                            IntegerLiteral( # input.cq:5:14..15
+                              value: 3
+                            )
+                          >
+                        )
+                        IndexItem(
+                          index: <
+                            IntegerLiteral( # input.cq:5:17..18
+                              value: 2
+                            )
+                          >
+                        )
+                      ]
+                    )
+                  >
+                )
+              ]
+            )
+          >
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/res/v3x/tests/integration/sgmq/cnot_q_0_q_3_2/input.cq
+++ b/res/v3x/tests/integration/sgmq/cnot_q_0_q_3_2/input.cq
@@ -1,0 +1,5 @@
+version 3
+
+qubit[4] q
+
+CNOT q[0], q[3, 2]

--- a/res/v3x/tests/integration/sgmq/cnot_q_0_q_3_2/semantic.3.0.golden.txt
+++ b/res/v3x/tests/integration/sgmq/cnot_q_0_q_3_2/semantic.3.0.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:5:1..5: qubit operands indices have different sizes


### PR DESCRIPTION
Add `check_qubit_operands_indices_have_same_size` and call it from `visit_gate_instruction` in the semantic analyzer.
Add `cnot_q_0_q_2_3` integration test.
Update CHANGELOG.md.