### PR TITLE
[CQT-386] Semantic analyzer does not check if number of parameters is correct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Fixed** for any bug fixes.
 - **Removed** for now removed features.
 
+## [ M.m.P ] - [ xxxx-y-zz ]
+
+### Added
+- Semantic analyzer checks if the number of provided instruction parameters are correct.
+
 
 ## [ 1.2.0 ] - [ 2025-03-27 ]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [ M.m.P ] - [ xxxx-y-zz ]
 
-### Added
-- Semantic analyzer checks if the number of provided instruction parameters are correct.
+### Fixed
+- Semantic analyzer throws exception if the number of provided instruction parameters are incorrect.
 
 
 ## [ 1.2.0 ] - [ 2025-03-27 ]

--- a/res/v3x/tests/integration/instruction/H_param/ast.golden.txt
+++ b/res/v3x/tests/integration/instruction/H_param/ast.golden.txt
@@ -1,0 +1,68 @@
+SUCCESS
+Program(
+  version: <
+    Version( # input.cq:1:9..12
+      items: 3.0
+    )
+  >
+  block: <
+    GlobalBlock(
+      statements: [
+        Variable( # input.cq:3:7..8
+          name: <
+            Identifier(
+              name: q
+            )
+          >
+          typ: <
+            Type( # input.cq:3:1..6
+              name: <
+                Keyword(
+                  name: qubit
+                )
+              >
+              size: -
+            )
+          >
+          annotations: []
+        )
+        GateInstruction( # input.cq:5:1..2
+          gate: <
+            Gate( # input.cq:5:1..2
+              name: <
+                Identifier(
+                  name: H
+                )
+              >
+              gate: -
+              parameters: <
+                ExpressionList(
+                  items: [
+                    IntegerLiteral( # input.cq:5:3..4
+                      value: 0
+                    )
+                    IntegerLiteral( # input.cq:5:5..6
+                      value: 1
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          >
+          operands: <
+            ExpressionList(
+              items: [
+                Identifier( # input.cq:5:8..9
+                  name: q
+                )
+              ]
+            )
+          >
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/res/v3x/tests/integration/instruction/H_param/input.cq
+++ b/res/v3x/tests/integration/instruction/H_param/input.cq
@@ -1,0 +1,5 @@
+version 3.0
+
+qubit q
+
+H(0,1) q

--- a/res/v3x/tests/integration/instruction/H_param/semantic.3.0.golden.txt
+++ b/res/v3x/tests/integration/instruction/H_param/semantic.3.0.golden.txt
@@ -1,2 +1,2 @@
 ERROR
-Error at input.cq:5:1..2: instruction 'H' expects 0 parameters, but got 2.
+Error at input.cq:5:1..2: instruction 'H' expects no parameters, but got 2.

--- a/res/v3x/tests/integration/instruction/H_param/semantic.3.0.golden.txt
+++ b/res/v3x/tests/integration/instruction/H_param/semantic.3.0.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:5:1..2: instruction 'H' expects 0 parameters, but got 2.

--- a/res/v3x/tests/integration/instruction/Rn_param/ast.golden.txt
+++ b/res/v3x/tests/integration/instruction/Rn_param/ast.golden.txt
@@ -1,0 +1,68 @@
+SUCCESS
+Program(
+  version: <
+    Version( # input.cq:1:9..12
+      items: 3.0
+    )
+  >
+  block: <
+    GlobalBlock(
+      statements: [
+        Variable( # input.cq:3:7..8
+          name: <
+            Identifier(
+              name: q
+            )
+          >
+          typ: <
+            Type( # input.cq:3:1..6
+              name: <
+                Keyword(
+                  name: qubit
+                )
+              >
+              size: -
+            )
+          >
+          annotations: []
+        )
+        GateInstruction( # input.cq:5:1..3
+          gate: <
+            Gate( # input.cq:5:1..3
+              name: <
+                Identifier(
+                  name: Rn
+                )
+              >
+              gate: -
+              parameters: <
+                ExpressionList(
+                  items: [
+                    IntegerLiteral( # input.cq:5:4..5
+                      value: 0
+                    )
+                    IntegerLiteral( # input.cq:5:6..7
+                      value: 1
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          >
+          operands: <
+            ExpressionList(
+              items: [
+                Identifier( # input.cq:5:9..10
+                  name: q
+                )
+              ]
+            )
+          >
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/res/v3x/tests/integration/instruction/Rn_param/input.cq
+++ b/res/v3x/tests/integration/instruction/Rn_param/input.cq
@@ -1,0 +1,5 @@
+version 3.0
+
+qubit q
+
+Rn(0,1) q

--- a/res/v3x/tests/integration/instruction/Rn_param/semantic.3.0.golden.txt
+++ b/res/v3x/tests/integration/instruction/Rn_param/semantic.3.0.golden.txt
@@ -1,0 +1,2 @@
+ERROR
+Error at input.cq:5:1..3: instruction 'Rn' expects 5 parameters, but got 2.

--- a/src/v3x/semantic_analyzer.cpp
+++ b/src/v3x/semantic_analyzer.cpp
@@ -218,11 +218,16 @@ values::Values resolve_parameters(const std::string& instruction_name, const val
     auto ret = values::Values{};
     const auto& instruction_set = InstructionSet::get_instance();
     const auto& param_types = instruction_set.get_instruction_param_types(instruction_name);
+    if (!param_types.has_value()) {
+        if (!parameters.empty()) {
+            throw error::AnalysisError{ fmt::format("instruction '{}' expects no parameters, but got {}.",
+                instruction_name, parameters.size()) };
+        }
+        return ret; // No parameters expected, and none provided — return empty result
+    }
     if (parameters.size() != param_types->size()) {
         throw error::AnalysisError{ fmt::format("instruction '{}' expects {} parameters, but got {}.",
-            instruction_name,
-            param_types->size(),
-            parameters.size()) };
+            instruction_name, param_types->size(), parameters.size()) };
     }
     if (param_types.has_value()) {
         std::for_each(param_types->begin(),

--- a/src/v3x/semantic_analyzer.cpp
+++ b/src/v3x/semantic_analyzer.cpp
@@ -219,11 +219,15 @@ values::Values resolve_parameters(const std::string& instruction_name, const val
     const auto& instruction_set = InstructionSet::get_instance();
     const auto& param_types = instruction_set.get_instruction_param_types(instruction_name);
     if (param_types.has_value()) {
+        if (parameters.size() != param_types->size()) {
+            throw error::AnalysisError{ fmt::format("Instruction '{}' expects {} parameters, but got {}.",
+                instruction_name, param_types->size(), parameters.size()) };
+        }
         std::for_each(param_types->begin(),
             param_types->end(),
-            [i = 0, &instruction_name, &parameters, &ret](const auto& param_type) mutable {
+            i = 0, &instruction_name, &parameters, &ret mutable {
                 if (!values::check_promote(values::type_of(parameters[i]), types::from_spec(param_type))) {
-                    throw error::AnalysisError{ fmt::format("failed to resolve '{}' with parameter type ({})",
+                    throw error::AnalysisError{ fmt::format("Failed to resolve '{}' with parameter type ({})",
                         instruction_name,
                         values::type_of(parameters[i])) };
                 }
@@ -233,6 +237,7 @@ values::Values resolve_parameters(const std::string& instruction_name, const val
     }
     return ret;
 }
+
 
 void check_gate(const tree::One<semantic::Gate>& gate) {
     if (!gate->gate.empty() && is_two_qubit_gate(gate->gate)) {

--- a/src/v3x/semantic_analyzer.cpp
+++ b/src/v3x/semantic_analyzer.cpp
@@ -220,14 +220,16 @@ values::Values resolve_parameters(const std::string& instruction_name, const val
     const auto& param_types = instruction_set.get_instruction_param_types(instruction_name);
     if (!param_types.has_value()) {
         if (!parameters.empty()) {
-            throw error::AnalysisError{ fmt::format("instruction '{}' expects no parameters, but got {}.",
-                instruction_name, parameters.size()) };
+            throw error::AnalysisError{ fmt::format(
+                "instruction '{}' expects no parameters, but got {}.", instruction_name, parameters.size()) };
         }
-        return ret; // No parameters expected, and none provided — return empty result
+        return ret;  // No parameters expected, and none provided — return empty result
     }
     if (parameters.size() != param_types->size()) {
         throw error::AnalysisError{ fmt::format("instruction '{}' expects {} parameters, but got {}.",
-            instruction_name, param_types->size(), parameters.size()) };
+            instruction_name,
+            param_types->size(),
+            parameters.size()) };
     }
     if (param_types.has_value()) {
         std::for_each(param_types->begin(),

--- a/src/v3x/semantic_analyzer.cpp
+++ b/src/v3x/semantic_analyzer.cpp
@@ -220,14 +220,16 @@ values::Values resolve_parameters(const std::string& instruction_name, const val
     const auto& param_types = instruction_set.get_instruction_param_types(instruction_name);
     if (param_types.has_value()) {
         if (parameters.size() != param_types->size()) {
-            throw error::AnalysisError{ fmt::format("Instruction '{}' expects {} parameters, but got {}.",
-                instruction_name, param_types->size(), parameters.size()) };
+            throw error::AnalysisError{ fmt::format("instruction '{}' expects {} parameters, but got {}.",
+                instruction_name,
+                param_types->size(),
+                parameters.size()) };
         }
         std::for_each(param_types->begin(),
             param_types->end(),
-            i = 0, &instruction_name, &parameters, &ret mutable {
+            [i = 0, &instruction_name, &parameters, &ret](const auto& param_type) mutable {
                 if (!values::check_promote(values::type_of(parameters[i]), types::from_spec(param_type))) {
-                    throw error::AnalysisError{ fmt::format("Failed to resolve '{}' with parameter type ({})",
+                    throw error::AnalysisError{ fmt::format("failed to resolve '{}' with parameter type ({})",
                         instruction_name,
                         values::type_of(parameters[i])) };
                 }
@@ -237,7 +239,6 @@ values::Values resolve_parameters(const std::string& instruction_name, const val
     }
     return ret;
 }
-
 
 void check_gate(const tree::One<semantic::Gate>& gate) {
     if (!gate->gate.empty() && is_two_qubit_gate(gate->gate)) {

--- a/src/v3x/semantic_analyzer.cpp
+++ b/src/v3x/semantic_analyzer.cpp
@@ -218,13 +218,13 @@ values::Values resolve_parameters(const std::string& instruction_name, const val
     auto ret = values::Values{};
     const auto& instruction_set = InstructionSet::get_instance();
     const auto& param_types = instruction_set.get_instruction_param_types(instruction_name);
+    if (parameters.size() != param_types->size()) {
+        throw error::AnalysisError{ fmt::format("instruction '{}' expects {} parameters, but got {}.",
+            instruction_name,
+            param_types->size(),
+            parameters.size()) };
+    }
     if (param_types.has_value()) {
-        if (parameters.size() != param_types->size()) {
-            throw error::AnalysisError{ fmt::format("instruction '{}' expects {} parameters, but got {}.",
-                instruction_name,
-                param_types->size(),
-                parameters.size()) };
-        }
         std::for_each(param_types->begin(),
             param_types->end(),
             [i = 0, &instruction_name, &parameters, &ret](const auto& param_type) mutable {

--- a/test/v3x/python/test_v3x_analyzer.py
+++ b/test/v3x/python/test_v3x_analyzer.py
@@ -91,7 +91,7 @@ class TestV3xAnalyzer(unittest.TestCase):
         program_str = "version 3;qubit q;H(0, 1) q"
         v3x_analyzer = cq.Analyzer()
         errors = v3x_analyzer.analyze_string(program_str)
-        expected_errors = ["Error at <unknown file name>:1:19..20: instruction 'H' expects 0 parameters, but got 2."]
+        expected_errors = ["Error at <unknown file name>:1:19..20: instruction 'H' expects no parameters, but got 2."]
         self.assertEqual(errors, expected_errors)
     
     def test_analyze_string_returning_errors_rx(self):

--- a/test/v3x/python/test_v3x_analyzer.py
+++ b/test/v3x/python/test_v3x_analyzer.py
@@ -86,6 +86,27 @@ class TestV3xAnalyzer(unittest.TestCase):
         errors = v3x_analyzer.analyze_string(program_str)
         expected_errors = ["Error at <unknown file name>:1:24..25: index 3 out of range (size 3)"]
         self.assertEqual(errors, expected_errors)
+    
+    def test_analyze_string_returning_errors_h(self):
+        program_str = "version 3;qubit q;H(0, 1) q"
+        v3x_analyzer = cq.Analyzer()
+        errors = v3x_analyzer.analyze_string(program_str)
+        expected_errors = ["Error at <unknown file name>:1:19..20: instruction 'H' expects 0 parameters, but got 2."]
+        self.assertEqual(errors, expected_errors)
+    
+    def test_analyze_string_returning_errors_rx(self):
+        program_str = "version 3;qubit q;Rx(0, 1) q"
+        v3x_analyzer = cq.Analyzer()
+        errors = v3x_analyzer.analyze_string(program_str)
+        expected_errors = ["Error at <unknown file name>:1:19..21: instruction 'Rx' expects 1 parameters, but got 2."]
+        self.assertEqual(errors, expected_errors)
+    
+    def test_analyze_string_returning_errors_rn(self):
+        program_str = "version 3;qubit q;Rn(0, 1) q"
+        v3x_analyzer = cq.Analyzer()
+        errors = v3x_analyzer.analyze_string(program_str)
+        expected_errors = ["Error at <unknown file name>:1:19..21: instruction 'Rn' expects 5 parameters, but got 2."]
+        self.assertEqual(errors, expected_errors)
 
     def test_to_json_vrsion(self):
         """This test is used to check that a program with a syntactic error


### PR DESCRIPTION
- Added parameter size check in `semantic_analyzer.cpp`.
- Added `Python` and `C++` tests.