### PR TITLE
[CQT-392] Release for Python 3.13

### DIFF
--- a/.github/actions/python-tests/action.yaml
+++ b/.github/actions/python-tests/action.yaml
@@ -10,7 +10,7 @@ runs:
   steps:
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.11"
+        python-version: "3.13"
     - name: Get latest CMake
       uses: lukka/get-cmake@latest
     - name: Install Python dependencies

--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==2.18.1
+          python -m pip install cibuildwheel==3.0.1
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/doc.yaml
+++ b/.github/workflows/doc.yaml
@@ -22,7 +22,7 @@ jobs:
           sudo apt-get install -y doxygen
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip -r requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Semantic analyzer check for same number of indices in each qubit operand.
-
+- Support for Python 3.13.
 
 ## [ 1.1.0 ] - [ 2025-03-13 ]
 

--- a/setup.py
+++ b/setup.py
@@ -161,6 +161,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Scientific/Engineering'
     ],
     packages=['libqasm', 'cqasm', 'cqasm.v3x'],


### PR DESCRIPTION
- Update to support Python 3.13.
- Update `cibuildwheel` package in tests to test include builds for Python 3.13.