### PR TITLE
Creating release 1.2.1

### DIFF
--- a/.github/workflows/assets.yaml
+++ b/.github/workflows/assets.yaml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-python@v5
       - name: Install cibuildwheel
         run: |
-          python -m pip install cibuildwheel==3.0.1
+          python -m pip install cibuildwheel==2.23.3
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Fixed** for any bug fixes.
 - **Removed** for now removed features.
 
-## [ M.m.P ] - [ xxxx-y-zz ]
+## [ 1.2.1 ] - [ 2025-07-28 ]
+
+### Added
+- Support for Python 3.13.
 
 ### Fixed
 - Semantic analyzer throws exception if the number of provided instruction parameters are incorrect.
@@ -19,7 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - Semantic analyzer check for same number of indices in each qubit operand.
-- Support for Python 3.13.
+
 
 ## [ 1.1.0 ] - [ 2025-03-13 ]
 

--- a/docs/dev-guide/cpp-dev-guide.md
+++ b/docs/dev-guide/cpp-dev-guide.md
@@ -7,7 +7,7 @@ The following line will also build and cache the `libqasm` Conan package.
 
 ```shell
 conan profile detect
-conan create --version 1.2.0 . -pr:a=tests-debug -b missing
+conan create --version 1.2.1 . -pr:a=tests-debug -b missing
 ```
 
 You can test the C++ binaries:

--- a/emscripten/test_libqasm.ts
+++ b/emscripten/test_libqasm.ts
@@ -8,7 +8,7 @@ wrapper().then(function(result: any) {
 
     try {
         let output = cqasm.get_version()
-        let expected_output = "1.2.0"
+        let expected_output = "1.2.1"
         console.log("\nThe version of libqasm compiled with emscripten is:", output);
         if (output !== expected_output) {
             console.log("\tExpected output:", expected_output)

--- a/include/libqasm/versioning.hpp
+++ b/include/libqasm/versioning.hpp
@@ -2,7 +2,7 @@
 
 namespace cqasm {
 
-static const char* version{ "1.2.0" };
+static const char* version{ "1.2.1" };
 static const char* release_year{ "2025" };
 
 [[nodiscard]] [[maybe_unused]] static const char* get_version() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libqasm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/QuTech-Delft/libqasm.git"


### PR DESCRIPTION
## [ 1.2.1 ] - [ 2025-07-28 ]

### Added
- Support for Python 3.13.

### Fixed
- Semantic analyzer throws exception if the number of provided instruction parameters are incorrect.
