### PR TITLE
[CQT-427] Add U Z90 and mZ90 gates to parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Fixed** for any bug fixes.
 - **Removed** for now removed features.
 
+## [ M.m.P ] - [ yyyy-mm-dd ]
+
+### Added
+- `U`, `Z90`, and `mZ90` unitary instructions.
+
+
 ## [ 1.2.1 ] - [ 2025-07-28 ]
 
 ### Added

--- a/conan/profiles/release-clang-emscripten-wasm
+++ b/conan/profiles/release-clang-emscripten-wasm
@@ -4,3 +4,4 @@ os=Emscripten
 build_type=Release
 compiler=clang
 compiler.version=14
+compiler.cppstd=20

--- a/res/v3x/tests/integration/instruction/U_param/ast.golden.txt
+++ b/res/v3x/tests/integration/instruction/U_param/ast.golden.txt
@@ -1,0 +1,71 @@
+SUCCESS
+Program(
+  version: <
+    Version( # input.cq:1:9..12
+      items: 3.0
+    )
+  >
+  block: <
+    GlobalBlock(
+      statements: [
+        Variable( # input.cq:3:7..8
+          name: <
+            Identifier(
+              name: q
+            )
+          >
+          typ: <
+            Type( # input.cq:3:1..6
+              name: <
+                Keyword(
+                  name: qubit
+                )
+              >
+              size: -
+            )
+          >
+          annotations: []
+        )
+        GateInstruction( # input.cq:5:1..2
+          gate: <
+            Gate( # input.cq:5:1..2
+              name: <
+                Identifier(
+                  name: U
+                )
+              >
+              gate: -
+              parameters: <
+                ExpressionList(
+                  items: [
+                    IntegerLiteral( # input.cq:5:3..4
+                      value: 1
+                    )
+                    IntegerLiteral( # input.cq:5:5..6
+                      value: 2
+                    )
+                    IntegerLiteral( # input.cq:5:7..8
+                      value: 3
+                    )
+                  ]
+                )
+              >
+              annotations: []
+            )
+          >
+          operands: <
+            ExpressionList(
+              items: [
+                Identifier( # input.cq:5:10..11
+                  name: q
+                )
+              ]
+            )
+          >
+          annotations: []
+        )
+      ]
+    )
+  >
+)
+

--- a/res/v3x/tests/integration/instruction/U_param/input.cq
+++ b/res/v3x/tests/integration/instruction/U_param/input.cq
@@ -1,0 +1,5 @@
+version 3.0
+
+qubit q
+
+U(1,2,3) q

--- a/res/v3x/tests/integration/instruction/U_param/semantic.3.0.golden.txt
+++ b/res/v3x/tests/integration/instruction/U_param/semantic.3.0.golden.txt
@@ -1,0 +1,64 @@
+SUCCESS
+Program(
+  api_version: 3.0
+  version: <
+    Version(
+      items: 3.0
+    )
+  >
+  block: <
+    Block(
+      statements: [
+        GateInstruction(
+          instruction_ref: U(qubit)
+          gate: <
+            Gate(
+              name: U
+              gate: -
+              parameters: [
+                ConstFloat(
+                  value: 1
+                )
+                ConstFloat(
+                  value: 2
+                )
+                ConstFloat(
+                  value: 3
+                )
+              ]
+              annotations: []
+            )
+          >
+          operands: [
+            VariableRef(
+              variable --> <
+                Variable(
+                  name: q
+                  typ: <
+                    Qubit(
+                      size: 1
+                    )
+                  >
+                  annotations: []
+                )
+              >
+            )
+          ]
+          annotations: []
+        )
+      ]
+    )
+  >
+  variables: [
+    Variable(
+      name: q
+      typ: <
+        Qubit(
+          size: 1
+        )
+      >
+      annotations: []
+    )
+  ]
+)
+

--- a/src/v3x/instruction_set.cpp
+++ b/src/v3x/instruction_set.cpp
@@ -33,6 +33,8 @@ InstructionSet::InstructionSet()
     { "mX90", { std::nullopt, "V" } },
     { "mY90", { std::nullopt, "Q" } },
     { "mY90", { std::nullopt, "V" } },
+    { "mZ90", { std::nullopt, "Q" } },
+    { "mZ90", { std::nullopt, "V" } },
     { "Rn", { "fffff", "Q" } },
     { "Rn", { "fffff", "V" } },
     { "Rx", { "f", "Q" } },
@@ -53,6 +55,8 @@ InstructionSet::InstructionSet()
     { "T", { std::nullopt, "V" } },
     { "Tdag", { std::nullopt, "Q" } },
     { "Tdag", { std::nullopt, "V" } },
+    { "U", { "fff", "Q" } },
+    { "U", { "fff", "V" } },
     { "X", { std::nullopt, "Q" } },
     { "X", { std::nullopt, "V" } },
     { "X90", { std::nullopt, "Q" } },
@@ -62,7 +66,9 @@ InstructionSet::InstructionSet()
     { "Y90", { std::nullopt, "Q" } },
     { "Y90", { std::nullopt, "V" } },
     { "Z", { std::nullopt, "Q" } },
-    { "Z", { std::nullopt, "V" } }
+    { "Z", { std::nullopt, "V" } },
+    { "Z90", { std::nullopt, "Q" } },
+    { "Z90", { std::nullopt, "V" } }
 }
 , non_gate_map{
     { "measure", { std::nullopt, "BQ" } },
@@ -84,7 +90,7 @@ InstructionSet::InstructionSet()
     { "ctrl", std::nullopt },
 }
 , single_qubit_named_gate_list{
-    "H", "I", "mX90", "mY90", "Rn", "Rx", "Ry", "Rz", "S", "Sdag", "T", "Tdag", "X", "X90", "Y", "Y90", "Z"
+    "H", "I", "mX90", "mY90", "mZ90", "Rn", "Rx", "Ry", "Rz", "S", "Sdag", "T", "Tdag", "U", "X", "X90", "Y", "Y90", "Z", "Z90"
 }
 , two_qubit_named_gate_list{
     "CNOT", "CR", "CRk", "CZ", "SWAP"

--- a/test/v3x/cpp/test_instruction_set.cpp
+++ b/test/v3x/cpp/test_instruction_set.cpp
@@ -18,10 +18,10 @@ protected:
     const InstructionListT& single_qubit_named_gate_list = instruction_set.get_single_qubit_named_gate_list();
     const InstructionListT& two_qubit_named_gate_list = instruction_set.get_two_qubit_named_gate_list();
 
-    const size_t number_of_gate_map_entries = 54;
+    const size_t number_of_gate_map_entries = 60;
     const size_t number_of_non_gate_map_entries = 12;
     const size_t number_of_gate_modifier_map_entries = 3;
-    const size_t number_of_single_qubit_named_gates = 17;
+    const size_t number_of_single_qubit_named_gates = 20;
     const size_t number_of_two_qubit_named_gates = 5;
 };
 


### PR DESCRIPTION
Added:
- `U`, `Z90`, and `mZ90` instructions
- test for U
- entry to Changelog