### PR TITLE
Creating release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,18 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - **Fixed** for any bug fixes.
 - **Removed** for now removed features.
 
+## [ 1.4.1 ] - [ 2026-06-15 ]
+
+### Fixed
+- Aliases `measureX`, `measureY`, and `measureZ`, for the `measure` instruction, recognized as tokens by the lexer.
+
+
 ## [ 1.4.0 ] - [ 2026-06-05 ]
 
 ### Added
 - `CV`, `CY`, `DCNOT`, `ECR`, `ISWAP`, `InvSqrtSWAP`, `M`, `MS`, `SqrtISWAP`, and `SqrtSWAP` unitary instructions.
 - Aliases `measureX`, `measureY`, and `measureZ`, for the `measure` instruction along the respective axes.
+
 
 ## [ 1.3.0 ] - [ 2026-03-23 ]
 

--- a/emscripten/test_libqasm.ts
+++ b/emscripten/test_libqasm.ts
@@ -8,7 +8,7 @@ wrapper().then(function(result: any) {
 
     try {
         let output = cqasm.get_version()
-        let expected_output = "1.4.0"
+        let expected_output = "1.4.1"
         console.log("\nThe version of libqasm compiled with emscripten is:", output);
         if (output !== expected_output) {
             console.log("\tExpected output:", expected_output)

--- a/include/libqasm/versioning.hpp
+++ b/include/libqasm/versioning.hpp
@@ -2,7 +2,7 @@
 
 namespace cqasm {
 
-static const char* version{ "1.4.0" };
+static const char* version{ "1.4.1" };
 static const char* release_year{ "2026" };
 
 [[nodiscard]] [[maybe_unused]] static const char* get_version() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "libqasm",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/QuTech-Delft/libqasm.git"


### PR DESCRIPTION
### Fixed
- Aliases `measureX`, `measureY`, and `measureZ`, for the `measure` instruction, recognized as tokens by the lexer.